### PR TITLE
fix: bracket outside conditional thing

### DIFF
--- a/src/commands/item.ts
+++ b/src/commands/item.ts
@@ -131,11 +131,11 @@ async function run(
 
   if (selected.sell || selected.buy) {
     desc.push(
-      `**worth** ${value ? `$${Math.floor(value).toLocaleString()}` : "[unvalued](https://nypsi.xyz/docs/economy/items/worth#unvalued"})`,
+      `**worth** ${value ? `$${Math.floor(value).toLocaleString()}` : "[unvalued](https://nypsi.xyz/docs/economy/items/worth#unvalued)"}`,
     );
   } else {
     desc.push(
-      `\n**worth** ${value ? `$${Math.floor(value).toLocaleString()}` : "[unvalued](https://nypsi.xyz/docs/economy/items/worth#unvalued"})`,
+      `\n**worth** ${value ? `$${Math.floor(value).toLocaleString()}` : "[unvalued](https://nypsi.xyz/docs/economy/items/worth#unvalued)"}`,
     );
   }
 


### PR DESCRIPTION
The brackets for worth were shifted 2 spaces too far to the right, causing the below output for the item command.

![image](https://github.com/user-attachments/assets/0fe08edf-6638-4082-b20f-cc765688b97b)

This change will clean this up and also fix the markdown for the unvalued link.