### PR TITLE
don't delete premium data on expire

### DIFF
--- a/src/scheduled/jobs/premiumexpire.ts
+++ b/src/scheduled/jobs/premiumexpire.ts
@@ -1,7 +1,6 @@
 import prisma from "../../init/database";
 import { Job } from "../../types/Jobs";
 import { expireUser } from "../../utils/functions/premium/premium";
-import dayjs = require("dayjs");
 
 export default {
   name: "premiumexpire",
@@ -9,7 +8,7 @@ export default {
   async run(log, manager) {
     const query = await prisma.premium.findMany({
       where: {
-        AND: [{ level: { gt: 0 } }, { credit: { lt: 1 } }, { expireDate: { lt: new Date() } }],
+        AND: [{ credit: { lt: 1 } }, { expireDate: { lt: new Date() } }],
       },
       select: {
         userId: true,
@@ -21,37 +20,6 @@ export default {
     }
 
     log(`${query.length} members expired`);
-
-    const gracePeriod = dayjs().subtract(21, "days").toDate();
-
-    const pastGracePeriod = await prisma.premium.findMany({
-      where: {
-        AND: [{ level: 0 }, { credit: { lt: 1 } }, { expireDate: { lt: gracePeriod } }],
-      },
-      select: {
-        userId: true,
-      },
-    });
-
-    for (const user of pastGracePeriod) {
-      await prisma.premiumCommand
-        .delete({
-          where: {
-            owner: user.userId,
-          },
-        })
-        .catch(() => {
-          // doesnt need to find one
-        });
-
-      await prisma.premium.delete({
-        where: {
-          userId: user.userId,
-        },
-      });
-    }
-
-    log(`${pastGracePeriod.length} members fully expired (past grace period)`);
 
     const reduceCredits = await prisma.premium.updateMany({
       where: {

--- a/src/scheduled/jobs/premiumexpire.ts
+++ b/src/scheduled/jobs/premiumexpire.ts
@@ -1,6 +1,7 @@
 import prisma from "../../init/database";
 import { Job } from "../../types/Jobs";
 import { expireUser } from "../../utils/functions/premium/premium";
+import dayjs = require("dayjs");
 
 export default {
   name: "premiumexpire",
@@ -8,7 +9,7 @@ export default {
   async run(log, manager) {
     const query = await prisma.premium.findMany({
       where: {
-        AND: [{ credit: { lt: 1 } }, { expireDate: { lt: new Date() } }],
+        AND: [{ level: { gt: 0 } }, { credit: { lt: 1 } }, { expireDate: { lt: new Date() } }],
       },
       select: {
         userId: true,
@@ -20,6 +21,37 @@ export default {
     }
 
     log(`${query.length} members expired`);
+
+    const gracePeriod = dayjs().subtract(21, "days").toDate();
+
+    const pastGracePeriod = await prisma.premium.findMany({
+      where: {
+        AND: [{ level: 0 }, { credit: { lt: 1 } }, { expireDate: { lt: gracePeriod } }],
+      },
+      select: {
+        userId: true,
+      },
+    });
+
+    for (const user of pastGracePeriod) {
+      await prisma.premiumCommand
+        .delete({
+          where: {
+            owner: user.userId,
+          },
+        })
+        .catch(() => {
+          // doesnt need to find one
+        });
+
+      await prisma.premium.delete({
+        where: {
+          userId: user.userId,
+        },
+      });
+    }
+
+    log(`${pastGracePeriod.length} members fully expired (past grace period)`);
 
     const reduceCredits = await prisma.premium.updateMany({
       where: {

--- a/src/utils/functions/economy/utils.ts
+++ b/src/utils/functions/economy/utils.ts
@@ -465,7 +465,12 @@ export async function reset() {
   await prisma.farm.deleteMany();
   await prisma.farmUpgrades.deleteMany();
   await prisma.$executeRaw`TRUNCATE TABLE "Farm" RESTART IDENTITY;`;
-
+  logger.info("deleting premium with tier 0");
+  await prisma.premium.deleteMany({
+    where: {
+      level: 0,
+    },
+  });
   logger.info("deleting banned/blacklisted");
   await prisma.economy.deleteMany({
     where: {

--- a/src/utils/functions/premium/premium.ts
+++ b/src/utils/functions/premium/premium.ts
@@ -274,8 +274,6 @@ export async function expireUser(member: string, client?: NypsiClient | ClusterM
       break;
   }
 
-  await redis.del(`${Constants.redis.cache.premium.LEVEL}:${member}`);
-
   if (client) {
     const cluster = await findGuildCluster(client, Constants.NYPSI_SERVER_ID);
 


### PR DESCRIPTION
on expire, premium tier gets set to 0. premium data is deleted when tier = 0 on new season

original:

This additions makes so that after user premium subscription expires it sets their premium level to 0 but reserves the premium data for 21 days in case the user would like to renew their premium after expiration. 

Any changes or something you like for me to change lmk

closes #1841 