### PR TITLE
fix: premium alises stripping all whitespace

### DIFF
--- a/src/commands/top.ts
+++ b/src/commands/top.ts
@@ -48,8 +48,12 @@ import {
 import { getItems } from "../utils/functions/economy/utils.js";
 import { getPrefix } from "../utils/functions/guilds/utils";
 import PageManager from "../utils/functions/page";
-import { commands } from "../utils/handlers/commandhandler";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler.js";
+import {
+  commandAliasExists,
+  commandExists,
+  getCommandFromAlias,
+} from "../utils/handlers/commandhandler";
 
 const cmd = new Command("top", "view top etc. in the server", "money").setAliases([
   "baltop",
@@ -596,10 +600,12 @@ async function run(
         title = `top command uses for ${message.guild.name}`;
       }
     } else {
-      const cmd = args[1]?.toLowerCase();
+      let cmd = args[1]?.toLowerCase();
 
-      if (!commands.has(cmd)) {
-        return send({ embeds: [new ErrorEmbed(`couldn't find ${cmd}`)] });
+      if (!commandExists(cmd)) {
+        if (commandAliasExists(cmd)) {
+          cmd = getCommandFromAlias(cmd);
+        } else return send({ embeds: [new ErrorEmbed(`couldn't find ${cmd}`)] });
       }
       let global = false;
 

--- a/src/utils/handlers/commandhandler.ts
+++ b/src/utils/handlers/commandhandler.ts
@@ -66,7 +66,7 @@ import { createProfile, hasProfile } from "../functions/users/utils";
 import dayjs = require("dayjs");
 import ms = require("ms");
 
-export const commands = new Map<string, Command>();
+const commands = new Map<string, Command>();
 const aliases = new Map<string, string>();
 const hourlyCommandCount = new Map<string, number>();
 const commandUses = new Map<string, number>();
@@ -698,6 +698,7 @@ export async function runCommand(
           .slice(1, Infinity)
           .join(" ")}`;
       } else if (recentlyUsedUserAliases.get(message.channel.id)?.has(cmd)) {
+        if (!cmd) return;
         const owner = recentlyUsedUserAliases.get(message.channel.id).get(cmd);
 
         return message.channel.send({
@@ -1148,11 +1149,15 @@ export async function runCommand(
 }
 
 export function commandExists(cmd: string) {
-  if (commands.has(cmd)) {
-    return true;
-  } else {
-    return false;
-  }
+  return commands.has(cmd);
+}
+
+export function commandAliasExists(alias: string) {
+  return aliases.has(alias);
+}
+
+export function getCommandFromAlias(alias: string) {
+  return aliases.get(alias);
 }
 
 function getCmdName(cmd: string): string {


### PR DESCRIPTION
closes #1843 

also allows for cmd aliases to be used when making an alias and on $top cmd
![image](https://github.com/user-attachments/assets/faa5f792-3919-454c-bb47-6e6416209f0b)
![image](https://github.com/user-attachments/assets/60d9924f-a0c6-4a02-8de6-864494cbd034)
![image](https://github.com/user-attachments/assets/7a72ec15-2e21-4deb-afeb-445dc0af3ffe)
![image](https://github.com/user-attachments/assets/1e4f6fff-a2d9-4514-b90f-85b1cfed2b4f)
![image](https://github.com/user-attachments/assets/65faefdd-e1ad-4e19-8d66-2974261ae1e7)

also, empty commands will no longer show the custom alias message so people just typing like "?" (not trynig to do a command) wont get a random error message
![image](https://github.com/user-attachments/assets/fa3084e8-20e0-4f10-9c28-7081477d3954)

