### PR TITLE
feat: add market order price confirmations

### DIFF
--- a/src/commands/avatarhistory.ts
+++ b/src/commands/avatarhistory.ts
@@ -81,17 +81,22 @@ async function run(
       const ext = avatar.split(".").pop().split("?")[0];
       const key = `avatar/${message.author.id}/${nanoid()}.${ext}`;
 
-      await s3.send(
-        new PutObjectCommand({
-          Bucket: process.env.S3_BUCKET,
-          Key: key,
-          Body: Buffer.from(arrayBuffer),
-          ContentType: `image/${ext}`,
-        }),
-      ).catch((err) => {
-        console.error(err);
-        logger.error(`error uploading avatar of ${message.author.id} (${message.author.username})`, {err});
-      });
+      await s3
+        .send(
+          new PutObjectCommand({
+            Bucket: process.env.S3_BUCKET,
+            Key: key,
+            Body: Buffer.from(arrayBuffer),
+            ContentType: `image/${ext}`,
+          }),
+        )
+        .catch((err) => {
+          console.error(err);
+          logger.error(
+            `error uploading avatar of ${message.author.id} (${message.author.username})`,
+            { err },
+          );
+        });
 
       await addNewAvatar(message.author.id, `https://cdn.nypsi.xyz/${key}`);
       logger.debug(`uploaded new avatar for ${message.author.id}`);

--- a/src/commands/captchatest.ts
+++ b/src/commands/captchatest.ts
@@ -21,7 +21,7 @@ async function run(
   }
 
   if (args.length == 2 && args[0].toLowerCase() == "verify") {
-    const target = (await getMember(message.guild, args[1]));
+    const target = await getMember(message.guild, args[1]);
 
     if (!target) {
       if (message instanceof Message) message.react("❌");
@@ -36,21 +36,21 @@ async function run(
     }
 
     const captcha = await prisma.captcha.update({
-      where: {id : res.id },
+      where: { id: res.id },
       data: {
         solved: true,
         solvedAt: new Date(),
-      }
+      },
     });
-    
+
     await redis.del(`${Constants.redis.nypsi.LOCKED_OUT}:${target.id}`);
     await passedCaptcha(target, captcha, true);
     await redis.del(`${Constants.redis.cache.user.CAPTCHA_HISTORY}:${target.id}`);
-    
+
     if (message instanceof Message) message.react("✅");
     return;
   }
-  
+
   for (const user of args) {
     giveCaptcha(user, 2, true);
     logger.info(`admin: ${message.author.id} (${message.author.username}) gave ${user} captcha`);

--- a/src/commands/case.ts
+++ b/src/commands/case.ts
@@ -383,9 +383,9 @@ async function run(
             attachment.url,
             attachment.contentType,
           );
-          
+
           if (res) evidencePrompt.delete().catch(() => {});
-          else { 
+          else {
             evidencePrompt.edit({ embeds: [new ErrorEmbed("failed to upload evidence")] });
             setInterval(() => evidencePrompt.delete().catch(() => {}), 3000);
           }

--- a/src/commands/logsearch.ts
+++ b/src/commands/logsearch.ts
@@ -32,7 +32,7 @@ async function run(
     `grep -rh "${args.join(" ").replaceAll('"', "").replaceAll("\\", "")}" out > ${path}`,
   ).catch((err) => {
     console.error(err);
-    logger.error("failed to complete logsearch", {err});
+    logger.error("failed to complete logsearch", { err });
   });
 
   if (!success) return (await msg).edit({ content: "failed to search logs" });

--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -441,7 +441,10 @@ async function run(
           return pageManager();
         }
 
-        let res: void | ModalSubmitInteraction | ButtonInteraction = await createOrderModal(type, interaction as ButtonInteraction);
+        let res: void | ModalSubmitInteraction | ButtonInteraction = await createOrderModal(
+          type,
+          interaction as ButtonInteraction,
+        );
 
         if (res) {
           const item = res.fields.fields.get("item").value;
@@ -767,14 +770,13 @@ async function run(
     cost: number,
     worth: number,
     type: OrderType,
-    msg?: NypsiMessage
+    msg?: NypsiMessage,
   ) => {
-    const embed = new CustomEmbed(message.member).setHeader(
-      "confirm",
-      message.author.avatarURL(),
+    const embed = new CustomEmbed(message.member).setHeader("confirm", message.author.avatarURL());
+
+    embed.setDescription(
+      `**are you sure you want to make a ${type} order at this price?**\nyou want to ${type} this item for $${cost.toLocaleString()}\nthe average worth for this item is $${worth.toLocaleString()}`,
     );
-    
-    embed.setDescription(`**are you sure you want to make a ${type} order at this price?**\nyou want to ${type} this item for $${cost.toLocaleString()}\nthe average worth for this item is $${worth.toLocaleString()}`);
 
     const row = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
       new ButtonBuilder().setCustomId("✅").setLabel("confirm").setStyle(ButtonStyle.Success),
@@ -817,7 +819,7 @@ async function run(
     }
 
     return { msg: msg, reaction: reaction as ButtonInteraction };
-  }
+  };
 
   const deleteOrder = async (
     type: string,
@@ -1203,7 +1205,7 @@ async function run(
     const cost = await formatBet(price.toLowerCase(), message.member).catch(() => {});
 
     if (!cost) return send({ embeds: [new ErrorEmbed("invalid price")] });
-    
+
     const itemWorth = await calcItemValue(selected.id);
 
     if (type == "buy") {
@@ -1262,7 +1264,7 @@ async function run(
       }
 
       if (createRes.url) description = `[${description}](${createRes.url})`;
-      
+
       if (msg) {
         return msg.edit({
           embeds: [new CustomEmbed(message.member, description)],
@@ -1349,7 +1351,7 @@ async function run(
       }
 
       if (createRes.url) description = `[${description}](${createRes.url})`;
-      
+
       if (msg) {
         return msg.edit({
           embeds: [new CustomEmbed(message.member, description)],

--- a/src/interactions/market_one.ts
+++ b/src/interactions/market_one.ts
@@ -128,12 +128,6 @@ export default {
 
     if (!res) return;
 
-    let value = Number(order.price);
-
-    if (order.orderType === "buy") {
-      value = Number(order.price);
-    }
-
     let deferred = false;
 
     if (order.orderType == "sell") {

--- a/src/utils/functions/captcha.ts
+++ b/src/utils/functions/captcha.ts
@@ -83,7 +83,7 @@ export async function passedCaptcha(member: GuildMember, check: Captcha, force =
         member.user.id
       }) has forcefully passed a captcha [${await redis.get(
         `${Constants.redis.cache.user.captcha_pass}:${member.user.id}`,
-      )}]`
+      )}]`,
     );
   } else {
     const timeTakenToSolve = check.solvedAt.getTime() - check.createdAt.getTime();

--- a/src/utils/functions/guilds/evidence.ts
+++ b/src/utils/functions/guilds/evidence.ts
@@ -1,4 +1,9 @@
-import { DeleteObjectCommand, DeleteObjectsCommand, PutObjectCommand, PutObjectCommandOutput } from "@aws-sdk/client-s3";
+import {
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  PutObjectCommand,
+  PutObjectCommandOutput,
+} from "@aws-sdk/client-s3";
 import { Guild } from "discord.js";
 import { nanoid } from "nanoid";
 import prisma from "../../../init/database";
@@ -69,7 +74,7 @@ export async function deleteEvidence(guild: Guild, caseId: number) {
       }),
     ).catch((err) => {
       console.error(err);
-      logger.error(`failed to delete evidence for case ${caseId} in ${guild.id}`, {err});
+      logger.error(`failed to delete evidence for case ${caseId} in ${guild.id}`, { err });
     });
 }
 
@@ -89,7 +94,7 @@ export async function deleteAllEvidence(guild: Guild) {
 
   await s3.send(cmd).catch((err) => {
     console.error(err);
-    logger.error(`failed to delete all evidence in ${guild.id}`, {err});
+    logger.error(`failed to delete all evidence in ${guild.id}`, { err });
   });
 
   await prisma.moderationEvidence.deleteMany({
@@ -127,17 +132,19 @@ export async function createEvidence(
 
   // if (buffer.byteLength < image.length) image = Buffer.from(buffer);
 
-  const success = await s3.send(
-    new PutObjectCommand({
-      Bucket: process.env.S3_BUCKET,
-      Key: key,
-      Body: image,
-      ContentType: contentType,
-    }),
-  ).catch((err) => {
-    console.error(err);
-    logger.error(`failed to upload evidence for case ${caseId} in ${guild.id}`, {err});
-  });
+  const success = await s3
+    .send(
+      new PutObjectCommand({
+        Bucket: process.env.S3_BUCKET,
+        Key: key,
+        Body: image,
+        ContentType: contentType,
+      }),
+    )
+    .catch((err) => {
+      console.error(err);
+      logger.error(`failed to upload evidence for case ${caseId} in ${guild.id}`, { err });
+    });
 
   if (!success) return false;
 

--- a/src/utils/functions/users/commands.ts
+++ b/src/utils/functions/users/commands.ts
@@ -136,16 +136,18 @@ export async function updateUser(user: User, command: string) {
         const ext = newAvatar.split(".").pop().split("?")[0];
         const key = `avatar/${user.id}/${nanoid()}.${ext}`;
 
-        const res = await s3.send(
-          new PutObjectCommand({
-            Bucket: process.env.S3_BUCKET,
-            Key: key,
-            Body: Buffer.from(arrayBuffer),
-            ContentType: `image/${ext}`,
-          }),
-        ).catch((err) => {
+        const res = await s3
+          .send(
+            new PutObjectCommand({
+              Bucket: process.env.S3_BUCKET,
+              Key: key,
+              Body: Buffer.from(arrayBuffer),
+              ContentType: `image/${ext}`,
+            }),
+          )
+          .catch((err) => {
             console.error(err);
-            logger.error(`failed to upload new avatar for ${user.id} (${username})`, {err});
+            logger.error(`failed to upload new avatar for ${user.id} (${username})`, { err });
           });
 
         if (!res) return;


### PR DESCRIPTION
works for both the buttons through `$mk -> manage -> create` and `$mk c <item> <b/s> <price>`

if youre confused why i made a bunch of things not edit reply and stuff i had to move the defer reply to later in the code to make sure i didnt have a random ephemeral thinking on the price confirm in the `$mk -> manage -> create path`

through the command works as it did with auctions, shows an expired message
![image](https://github.com/user-attachments/assets/ea545441-95d4-4e19-94a5-6aa8b8711a17)

if it expires/is cancelled through `$mk -> manage -> create path`, it just resets the embed to the manage menu
![image](https://github.com/user-attachments/assets/bb7e83b0-21ee-4087-81e7-2288fe46eb8f)
