### PR TITLE
add a pluralize function

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -2448,6 +2448,7 @@
   "reroll_token": {
     "id": "reroll_token",
     "name": "reroll token",
+    "plural": "reroll tokens",
     "emoji": "<:reroll_token:1150463797497184307>",
     "longDesc": "reroll a permanent upgrade into a different one",
     "sell": 25000000,
@@ -2959,6 +2960,7 @@
   "fertiliser": {
     "id": "fertiliser",
     "name": "fertiliser",
+    "plural": "fertilisers",
     "article": "a",
     "emoji": "<:fertiliser:1314233680406777947>",
     "longDesc": "used to grow plants and keep them healthy",

--- a/src/commands/achievements.ts
+++ b/src/commands/achievements.ts
@@ -25,6 +25,7 @@ import {
 import { getAchievements, getItems, getTagsData } from "../utils/functions/economy/utils";
 import PageManager from "../utils/functions/page";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
+import { pluralize } from "../utils/functions/string";
 
 const cmd = new Command("achievements", "view your achievement progress", "money").setAliases([
   "ach",
@@ -192,9 +193,7 @@ async function run(
         if (!achData) continue;
 
         if (achData.completed) {
-          str += `\`completed ${daysAgo(achData.completedAt).toLocaleString()} day${
-            daysAgo(achData.completedAt) == 1 ? "" : "s"
-          } ago\``;
+          str += `\`completed ${daysAgo(achData.completedAt).toLocaleString()} ${pluralize("day", daysAgo(achData.completedAt))} ago\``;
         } else {
           str += `\`${achData.progress.toLocaleString()} / ${achievement.target.toLocaleString()} (${(
             (Number(achData.progress) / achievement.target) *

--- a/src/commands/craft.ts
+++ b/src/commands/craft.ts
@@ -25,6 +25,7 @@ import { addStat } from "../utils/functions/economy/stats";
 import { createUser, getItems, userExists } from "../utils/functions/economy/utils";
 import { getTier, isPremium } from "../utils/functions/premium/premium";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
+import { pluralize } from "../utils/functions/string";
 
 const cmd = new Command("craft", "craft items", "money");
 
@@ -495,9 +496,10 @@ async function run(
       embeds: [
         new CustomEmbed(
           message.member,
-          `\`${amount.toLocaleString()}x\` ${selected.emoji} ${
-            amount > 1 ? selected.plural || selected.name : selected.name
-          } will be crafted <t:${Math.floor(craft.finished.getTime() / 1000)}:R>`,
+          `\`${amount.toLocaleString()}x\` ${selected.emoji} ${pluralize(
+            selected,
+            amount,
+          )} will be crafted <t:${Math.floor(craft.finished.getTime() / 1000)}:R>`,
         ),
       ],
     });

--- a/src/commands/crateall.ts
+++ b/src/commands/crateall.ts
@@ -5,6 +5,7 @@ import Constants from "../utils/Constants";
 import { addInventoryItem } from "../utils/functions/economy/inventory";
 import { getItems, userExists } from "../utils/functions/economy/utils";
 import { logger } from "../utils/logger";
+import { pluralize } from "../utils/functions/string";
 
 const cmd = new Command(
   "crateall",
@@ -92,12 +93,7 @@ async function run(
   await Promise.all(promises);
 
   return message.channel.send({
-    embeds: [
-      new CustomEmbed(
-        message.member,
-        `**${count}** ${selected.name}${count != 1 ? "s" : ""} given`,
-      ),
-    ],
+    embeds: [new CustomEmbed(message.member, `**${count}** ${pluralize(selected, count)} given`)],
   });
 }
 

--- a/src/commands/farm.ts
+++ b/src/commands/farm.ts
@@ -214,10 +214,9 @@ async function run(
 
         const owned =
           userUpgrades.find((u) => u.upgradeId == upgradeId && u.plantId === selected)?.amount || 0;
-        const pluralName = upgrade.plural ? upgrade.plural : upgrade.name;
 
         if (upgrade.type_single) {
-          desc += `**${pluralName}** ${owned}/${upgrade.type_single.stack_limit}`;
+          desc += `**${upgrade.plural}** ${owned}/${upgrade.type_single.stack_limit}`;
         } else if (upgrade.type_upgradable) {
           desc += `**${upgrade.name}** ${owned == 0 ? "none" : getItems()[upgrade.type_upgradable.items[owned - 1]].name}`;
         }
@@ -229,7 +228,7 @@ async function run(
         const maxButton = new ButtonBuilder()
           .setCustomId(`up-${upgradeId}-max`)
           .setEmoji("⏫")
-          .setLabel(`add all ${pluralName}`);
+          .setLabel(`add all ${upgrade.plural}`);
 
         if (
           owned < upgrade.type_single?.stack_limit ||
@@ -322,9 +321,7 @@ async function run(
 
           if (itemCount === 0) {
             await interaction.reply({
-              embeds: [
-                new ErrorEmbed(`you don't have any ${item.plural ? item.plural : item.name}`),
-              ],
+              embeds: [new ErrorEmbed(`you don't have any ${item.plural}`)],
               flags: MessageFlags.Ephemeral,
             });
             return listen();
@@ -337,11 +334,7 @@ async function run(
 
           if (userUpgradeCount >= upgrade.type_single.stack_limit) {
             await interaction.reply({
-              embeds: [
-                new ErrorEmbed(
-                  `you already have the max amount of ${item.plural ? item.plural : item.name}`,
-                ),
-              ],
+              embeds: [new ErrorEmbed(`you already have the max amount of ${item.plural}`)],
               flags: MessageFlags.Ephemeral,
             });
             return listen();

--- a/src/commands/give.ts
+++ b/src/commands/give.ts
@@ -156,9 +156,7 @@ async function run(
     inventory.find((i) => i.item == selected.id).amount < 1
   ) {
     return send({
-      embeds: [
-        new ErrorEmbed("you dont have any " + (selected.plural ? selected.plural : selected.name)),
-      ],
+      embeds: [new ErrorEmbed("you dont have any " + selected.plural)],
     });
   }
 

--- a/src/commands/item.ts
+++ b/src/commands/item.ts
@@ -23,6 +23,7 @@ import { countItemOnMarket } from "../utils/functions/economy/market";
 import { createUser, userExists } from "../utils/functions/economy/utils";
 import { getEmojiImage } from "../utils/functions/image";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
+import { pluralize } from "../utils/functions/string";
 
 const cmd = new Command("item", "view information about an item", "money").setAliases(["i"]);
 
@@ -174,11 +175,10 @@ async function run(
 
     if (inventory.find((i) => i.item == selected.id)) {
       embed.setFooter({
-        text: `you have ${inventory.find((i) => i.item == selected.id).amount.toLocaleString()} ${
-          inventory.find((i) => i.item == selected.id).amount > 1
-            ? selected.plural || selected.name
-            : selected.name
-        }`,
+        text: `you have ${inventory.find((i) => i.item == selected.id).amount.toLocaleString()} ${pluralize(
+          selected,
+          inventory.find((i) => i.item == selected.id).amount,
+        )}`,
       });
     }
   }

--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -63,6 +63,7 @@ import { getEmojiImage } from "../utils/functions/image";
 import { getTier, isPremium } from "../utils/functions/premium/premium";
 import { getAdminLevel } from "../utils/functions/users/admin";
 import { addCooldown, addExpiry, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
+import { pluralize } from "../utils/functions/string";
 
 const cmd = new Command(
   "market",
@@ -589,11 +590,7 @@ async function run(
               inventory.find((i) => i.item == selected.id).amount < parseInt(amount)
             ) {
               await res.editReply({
-                embeds: [
-                  new ErrorEmbed(
-                    `you dont have enough ${selected.plural ? selected.plural : selected.name}`,
-                  ),
-                ],
+                embeds: [new ErrorEmbed(`you dont have enough ${selected.plural}`)],
                 options: { flags: MessageFlags.Ephemeral },
               });
               await updateEmbed();
@@ -1104,9 +1101,7 @@ async function run(
       -1
     ) {
       return send({
-        embeds: [
-          new ErrorEmbed(`not enough ${item.plural ? item.plural : item.name} on the market`),
-        ],
+        embeds: [new ErrorEmbed(`not enough ${item.plural} on the market`)],
       });
     }
 
@@ -1130,9 +1125,7 @@ async function run(
       -1
     ) {
       return send({
-        embeds: [
-          new ErrorEmbed(`not enough ${item.plural ? item.plural : item.name} on the market`),
-        ],
+        embeds: [new ErrorEmbed(`not enough ${item.plural} on the market`)],
       });
     }
 
@@ -1143,9 +1136,7 @@ async function run(
       inventory.find((i) => i.item == item.id).amount < 1
     ) {
       return send({
-        embeds: [
-          new ErrorEmbed(`you do not have this many ${item.plural ? item.plural : item.name}`),
-        ],
+        embeds: [new ErrorEmbed(`you do not have this many ${item.plural}`)],
       });
     }
 
@@ -1283,11 +1274,7 @@ async function run(
         inventory.find((i) => i.item == selected.id).amount < parseInt(amount)
       ) {
         return send({
-          embeds: [
-            new ErrorEmbed(
-              `you dont have enough ${selected.plural ? selected.plural : selected.name}`,
-            ),
-          ],
+          embeds: [new ErrorEmbed(`you dont have enough ${selected.plural}`)],
         });
       }
 
@@ -1651,9 +1638,7 @@ async function run(
           inventory.find((i) => i.item == item.id).amount < 1
         ) {
           await interaction.reply({
-            embeds: [
-              new ErrorEmbed(`you do not have this many ${item.plural ? item.plural : item.name}`),
-            ],
+            embeds: [new ErrorEmbed(`you do not have this many ${item.plural}`)],
             flags: MessageFlags.Ephemeral,
           });
           await updateEmbed();
@@ -1720,11 +1705,7 @@ async function run(
             inventory.find((i) => i.item == item.id).amount < 1
           ) {
             await interaction.editReply({
-              embeds: [
-                new ErrorEmbed(
-                  `you do not have this many ${item.plural ? item.plural : item.name}`,
-                ),
-              ],
+              embeds: [new ErrorEmbed(`you do not have this many ${item.plural}`)],
               options: { flags: MessageFlags.Ephemeral },
             });
             await updateEmbed();
@@ -1767,7 +1748,7 @@ async function run(
     ).cost;
 
     embed.setDescription(
-      `are you sure you want to ${type} ${amount} ${amount == 1 || !item.plural ? item.name : item.plural} for $${price.toLocaleString()}?`,
+      `are you sure you want to ${type} ${amount} ${pluralize(item, amount)} for $${price.toLocaleString()}?`,
     );
 
     const row = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
@@ -1844,11 +1825,11 @@ async function run(
 
         if (res.status === "partial") {
           embed.setDescription(
-            `✅ ${type == "buy" ? "bought" : "sold"} ${amount} ${item.emoji} ${amount == 1 || !item.plural ? item.name : item.plural} for $${price.toLocaleString()}`,
+            `✅ ${type == "buy" ? "bought" : "sold"} ${amount} ${item.emoji} ${pluralize(item, amount)} for $${price.toLocaleString()}`,
           );
         } else {
           embed.setDescription(
-            `✅ ${type == "buy" ? "bought" : "sold"} ${amount.toLocaleString()} ${item.emoji} ${amount == 1 || !item.plural ? item.name : item.plural} for $${price.toLocaleString()}`,
+            `✅ ${type == "buy" ? "bought" : "sold"} ${amount.toLocaleString()} ${item.emoji} ${pluralize(item, amount)} for $${price.toLocaleString()}`,
           );
         }
 

--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -41,6 +41,7 @@ import PageManager from "../utils/functions/page";
 import { addTag, getTags } from "../utils/functions/users/tags";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 import { logger } from "../utils/logger";
+import { pluralize } from "../utils/functions/string";
 
 const itemFunctions = new Map<string, ItemUse>();
 
@@ -242,12 +243,11 @@ async function run(
 
     if (["cake", "cookie", "lucky_cheese"].includes(selected.id)) {
       addTaskProgress(message.author.id, "eat_cookies", amount);
-      desc = `eating ${amount > 1 ? `${amount} ` : ""}**${
-        amount > 1 ? selected.plural || selected.name : selected.name
-      }**...`;
-      desc2 = `you have eaten ${amount > 1 ? `${amount} ` : "a "}**${
-        amount > 1 ? selected.plural || selected.name : selected.name
-      }** 😋`;
+      desc = `eating ${amount > 1 ? `${amount} ` : ""}**${pluralize(selected, amount)}**...`;
+      desc2 = `you have eaten ${amount > 1 ? `${amount} ` : "a "}**${pluralize(
+        selected,
+        amount,
+      )}** 😋`;
     }
 
     embed.setDescription(desc);
@@ -362,9 +362,10 @@ async function run(
       embeds: [
         new CustomEmbed(
           message.member,
-          `you have activated ${amount} **${
-            amount != 1 && upgrade.plural ? upgrade.plural : upgrade.name
-          }** on your **${getBaseWorkers()[upgrade.for].name}**\n\n${
+          `you have activated ${amount} **${pluralize(
+            upgrade,
+            amount,
+          )}** on your **${getBaseWorkers()[upgrade.for].name}**\n\n${
             userUpgrade ? userUpgrade.amount + amount : amount
           }/${upgrade.stack_limit}`,
         ).setHeader("use", message.author.avatarURL()),
@@ -476,7 +477,7 @@ async function run(
       embeds: [
         new CustomEmbed(
           message.member,
-          `you've planted ${amount} ${amount > 1 ? selected.plural : selected.name} in your farm` +
+          `you've planted ${amount} ${pluralize(selected, amount)} in your farm` +
             (farm.length === amount
               ? "\n\nif you're new to farming, it's recommended you read the [farm care guide](https://nypsi.xyz/docs/economy/farm?ref=bot-help#caring-for-your-farm) to make sure you don't kill your plants"
               : ""),

--- a/src/scheduled/jobs/weeklycrates.ts
+++ b/src/scheduled/jobs/weeklycrates.ts
@@ -4,6 +4,7 @@ import { Job } from "../../types/Jobs";
 import Constants from "../../utils/Constants";
 import { addInventoryItem } from "../../utils/functions/economy/inventory";
 import { getItems } from "../../utils/functions/economy/utils";
+import { pluralize } from "../../utils/functions/string";
 import { addNotificationToQueue, getDmSettings } from "../../utils/functions/users/notifications";
 
 export default {
@@ -61,15 +62,7 @@ export default {
       for (const [key, value] of rewards.entries()) {
         log(`${member.id} receiving ${value}x ${key}`);
         await addInventoryItem(member.id, key, value);
-        desc.push(
-          `+**${value}** ${getItems()[key].emoji} ${
-            value > 1
-              ? getItems()[key].plural
-                ? getItems()[key].plural
-                : getItems()[key].name
-              : getItems()[key].name
-          }`,
-        );
+        desc.push(`+**${value}** ${getItems()[key].emoji} ${pluralize(getItems()[key], value)}`);
       }
 
       embed.addField("rewards", desc.join("\n"));

--- a/src/types/Economy.ts
+++ b/src/types/Economy.ts
@@ -24,7 +24,7 @@ export interface Item {
     time: number;
   };
   worker_upgrade_id?: string;
-  plural?: string;
+  plural: string;
   article: string;
   craft?: {
     ingredients: string[]; // format: item_id:amount
@@ -128,7 +128,7 @@ export type Plant = {
 export type PlantUpgrade = {
   id: string;
   name: string;
-  plural?: string;
+  plural: string;
   upgrades: string;
   effect: number;
   for?: string[]; // use if upgrade is only for select plants

--- a/src/utils/functions/economy/items/crates.ts
+++ b/src/utils/functions/economy/items/crates.ts
@@ -22,6 +22,7 @@ import { openCrate } from "../loot_pools";
 import { addStat } from "../stats";
 import { addTaskProgress } from "../tasks";
 import { getItems } from "../utils";
+import { pluralize } from "../../string";
 
 module.exports = new ItemUse(
   "crates",
@@ -100,13 +101,9 @@ module.exports = new ItemUse(
 
     const embed = new CustomEmbed(
       message.member,
-      `opening **${amount}** ${
-        amount > 1 ? (selected.plural ? selected.plural : selected.name) : selected.name
-      }`,
+      `opening **${amount}** ${pluralize(selected, amount)}`,
     ).setHeader(
-      `${message.author.username}'s ${amount} ${
-        amount > 1 ? (selected.plural ? selected.plural : selected.name) : selected.name
-      }`,
+      `${message.author.username}'s ${amount} ${pluralize(selected, amount)}`,
       message.author.avatarURL(),
     );
 

--- a/src/utils/functions/economy/market.ts
+++ b/src/utils/functions/economy/market.ts
@@ -34,6 +34,7 @@ import { addInventoryItem, getInventory, removeInventoryItem } from "./inventory
 import { addStat } from "./stats";
 import { createUser, getItems, userExists } from "./utils";
 import ms = require("ms");
+import { pluralize } from "../string";
 
 const inTransaction = new Set<string>();
 /**
@@ -577,11 +578,7 @@ export async function checkMarketWatchers(
   const payload: NotificationPayload = {
     payload: {
       embed: new CustomEmbed().setDescription(
-        `a ${type} order has made been for ${amount} ${getItems()[itemId].emoji} **[${
-          amount == 1 || !getItems()[itemId].plural
-            ? getItems()[itemId].name
-            : getItems()[itemId].plural
-        }](https://nypsi.xyz/item/${itemId}?ref=bot-market)**`,
+        `a ${type} order has made been for ${amount} ${getItems()[itemId].emoji} **[${pluralize(getItems()[itemId], amount)}](https://nypsi.xyz/item/${itemId}?ref=bot-market)**`,
       ),
       components: new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
         new ButtonBuilder().setStyle(ButtonStyle.Link).setLabel("jump").setURL(url),
@@ -994,7 +991,7 @@ export async function marketSell(
     await redis.del(`${Constants.redis.nypsi.MARKET_IN_TRANSACTION}:${itemId}`);
     inTransaction.delete(itemId);
     return {
-      status: `you do not have this many ${getItems()[itemId].plural ? getItems()[itemId].plural : getItems()[itemId].name}`,
+      status: `you do not have this many ${getItems()[itemId].plural}`,
       remaining: -1,
     };
   }

--- a/src/utils/functions/economy/top.ts
+++ b/src/utils/functions/economy/top.ts
@@ -5,7 +5,7 @@ import { inPlaceSort } from "fast-sort";
 import prisma from "../../../init/database";
 import PageManager from "../page";
 import sleep from "../sleep";
-import { formatTime } from "../string";
+import { formatTime, pluralize } from "../string";
 import { getPreferences } from "../users/notifications";
 import { getLastKnownUsername } from "../users/tag";
 import { getActiveTag } from "../users/tags";
@@ -523,15 +523,11 @@ export async function topItem(guild: Guild, item: string, userId: string) {
       pos += ".";
     }
 
-    const items = getItems();
-
     out[count] = `${pos} ${await formatUsername(
       user.userId,
       members.get(user.userId).user.username,
       true,
-    )} ${user.amount.toLocaleString()} ${
-      user.amount > 1 ? items[item].plural || items[item].name : items[item].name
-    }`;
+    )} ${user.amount.toLocaleString()} ${pluralize(getItems()[item], user.amount)}`;
 
     count++;
   }
@@ -594,15 +590,11 @@ export async function topItemGlobal(item: string, userId: string, amount = 100) 
       pos += ".";
     }
 
-    const items = getItems();
-
     out[count] = `${pos} ${await formatUsername(
       user.userId,
       user.economy.user.lastKnownUsername,
       (await getPreferences(user.userId)).leaderboards,
-    )} ${user.amount.toLocaleString()} ${
-      user.amount > 1 ? items[item].plural || items[item].name : items[item].name
-    }`;
+    )} ${user.amount.toLocaleString()} ${pluralize(getItems()[item], user.amount)}`;
 
     count++;
   }

--- a/src/utils/functions/economy/utils.ts
+++ b/src/utils/functions/economy/utils.ts
@@ -36,6 +36,7 @@ import { addXp } from "./xp";
 import ms = require("ms");
 import math = require("mathjs");
 import pAll = require("p-all");
+import { pluralize } from "../string";
 
 let items: { [key: string]: Item };
 let achievements: { [key: string]: AchievementData };
@@ -748,7 +749,7 @@ export async function doDaily(member: GuildMember, updateLast = true, amount = 1
     });
 
     rewards.push(
-      `+ **${amount.toLocaleString()}** ${items[itemId].emoji} ${amount > 1 && items[itemId].plural ? items[itemId].plural : items[itemId].name}`,
+      `+ **${amount.toLocaleString()}** ${items[itemId].emoji} ${pluralize(items[itemId], amount)}`,
     );
   }
 

--- a/src/utils/functions/economy/workers.ts
+++ b/src/utils/functions/economy/workers.ts
@@ -11,6 +11,7 @@ import { addInventoryItem, gemBreak, getInventory } from "./inventory";
 import { addStat } from "./stats";
 import { getBaseUpgrades, getBaseWorkers, getItems } from "./utils";
 import { Worker, WorkerByproducts } from "../../../types/Workers";
+import { pluralize } from "../string";
 
 export async function getWorkers(member: GuildMember | string) {
   let id: string;
@@ -366,9 +367,10 @@ export async function claimFromWorkers(userId: string): Promise<string> {
       : `\n\n${byproducts
           .map(
             (x) =>
-              `you found **${totalByproducts.get(x)}** ${allItems[x].emoji} ${
-                totalByproducts.get(x) > 1 ? allItems[x].plural : allItems[x].name
-              }`,
+              `you found **${totalByproducts.get(x)}** ${allItems[x].emoji} ${pluralize(
+                allItems[x],
+                totalByproducts.get(x),
+              )}`,
           )
           .join("\n")}`)
   );

--- a/src/utils/functions/presence.ts
+++ b/src/utils/functions/presence.ts
@@ -4,6 +4,7 @@ import Constants from "../Constants";
 import { daysUntilChristmas } from "./date";
 import { getTotalAmountOfItem } from "./economy/inventory";
 import { getItems } from "./economy/utils";
+import { pluralize } from "./string";
 
 export async function randomPresence(): Promise<ActivitiesOptions> {
   const possibilities: ActivitiesOptions[] = [
@@ -51,7 +52,7 @@ export async function randomPresence(): Promise<ActivitiesOptions> {
     const items = Object.values(getItems());
     const item = items[Math.floor(Math.random() * items.length)];
     const count = await getTotalAmountOfItem(item.id);
-    chosen.name = `${count.toLocaleString()} ${!item.emoji.includes("<") ? `${item.emoji} ` : ""}${count !== 1 ? (item.plural ? item.plural : item.name + "s") : item.name}`;
+    chosen.name = `${count.toLocaleString()} ${!item.emoji.includes("<") ? `${item.emoji} ` : ""}${pluralize(item, count)}`;
   }
 
   return chosen;

--- a/src/utils/functions/string.ts
+++ b/src/utils/functions/string.ts
@@ -1,4 +1,6 @@
 import * as CryptoJS from "crypto-js";
+import { Item, PlantUpgrade } from "../../types/Economy";
+import { WorkerUpgrades } from "../../types/Workers";
 
 export function cleanString(string: string): string {
   return string.replace(/[^A-z0-9\s]/g, "").toLowerCase();
@@ -77,4 +79,17 @@ export function formatTime(ms: number) {
   }
 
   return `${minutes > 0 ? `${minutes}m` : ""}${seconds}s`;
+}
+
+export function pluralize(text: string, amount: number | bigint, plural?: string): string;
+export function pluralize(item: Item, amount: number | bigint): string;
+export function pluralize(upgrade: WorkerUpgrades, amount: number | bigint): string;
+export function pluralize(upgrade: PlantUpgrade, amount: number | bigint): string;
+export function pluralize(
+  data: string | Item | WorkerUpgrades | PlantUpgrade,
+  amount: number | bigint,
+  plural?: string,
+) {
+  if (typeof data == "string") return amount == 1 ? data : (plural ?? `${data}s`);
+  return amount == 1 ? data.name : (data.plural ?? data.name);
 }

--- a/src/utils/handlers/webhookhandler.ts
+++ b/src/utils/handlers/webhookhandler.ts
@@ -51,6 +51,7 @@ import {
 } from "../functions/users/notifications";
 import { logger } from "../logger";
 import ms = require("ms");
+import { pluralize } from "../functions/string";
 
 loadItems(false);
 
@@ -294,12 +295,12 @@ async function doVote(vote: topgg.WebhookPayload) {
       "you have received the following: \n\n" +
         `+ $**${amount.toLocaleString()}**\n` +
         "+ **3**% multiplier\n" +
-        `+ **${crateAmount}** vote crate${crateAmount != 1 ? "s" : ""}` +
-        `\n+ **${crateAmount}** lottery ticket${crateAmount !== 1 ? "s" : ""}\n\n` +
+        `+ **${crateAmount}** ${pluralize("vote crate", crateAmount)}` +
+        `\n+ **${crateAmount}** ${pluralize("lottery ticket", crateAmount)}\n\n` +
         (newCrateAmount && votes.voteStreak > 5
           ? `you will now receive **${crateAmount}** crates each vote thanks to your streak\n\n`
           : "") +
-        `you have voted **${votes.monthVote}** time${votes.monthVote > 1 ? "s" : ""} this month`,
+        `you have voted **${votes.monthVote}** ${pluralize("time", votes.monthVote)} this month`,
     )
     .setFooter({ text: `+100xp | streak: ${votes.voteStreak.toLocaleString()}` });
 


### PR DESCRIPTION
this is not yet complete because i want your opinion on it before i continue doing the rest of the stuff

pluralize() gives an easier way to make things plural without a ternary operator & keeps it consistent (currently some places use `amount > 1`, others `amount != 1`, others `amount == 1`)

has easy integration with Item, WorkerUpgrade, and PlantUpgrade (may expand if i see other places that it would be good in)

can turn `amount == 1 ? item.name : item.plural` into `pluralize(item, amount)`

for strings, you give the unpluralized text (ex. test), the amount, and then optionally the plural (if none is provided, it by default just adds an s)

`pluralize("test", 1)` -> `test`
`pluralize("test", 69)` -> `tests`

or

`pluralize("ass", 1, "asses")` -> `ass`
`pluralize("ass", 69, "asses)` -> `asses`

(it takes in the whole plural word because of cases such as leaf -> leaves)

what do you think of having this function