### PR TITLE
dont have separate confirmation msg

### DIFF
--- a/src/utils/functions/economy/market.ts
+++ b/src/utils/functions/economy/market.ts
@@ -1230,10 +1230,8 @@ export async function showMarketConfirmationModal(
     });
     return false;
   }
-  res.reply({
-    embeds: [new CustomEmbed(null, "✅ confirmation accepted")],
-    flags: MessageFlags.Ephemeral,
-  });
+  
+  res.deferUpdate();
 
   return true;
 }


### PR DESCRIPTION
in agreement with bharati, just useless and clunky to have the confirm accept message as well as the fulfill info
how it was:
![image](https://github.com/user-attachments/assets/2ea3d28d-63b5-4b8f-89f8-15b80786cbe8)

confirmation accepted embed msg now gone