### PR TITLE
feat: add marriage functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - gems can now be broken in farm
 - green gem can be broken
 - you get a cake for your birthday (@growling_grizzly)
+- you can now /marry someone (@growling_grizzly)
 
 ## other
 

--- a/data/items.json
+++ b/data/items.json
@@ -1084,11 +1084,22 @@
     "name": "ring",
     "article": "a",
     "plural": "rings",
-    "emoji": "💍",
+    "emoji": "<:nypsi_ring:1384728690986061844>",
     "longDesc": "maybe get married?",
     "rarity": 4,
     "role": "collectable",
     "in_crates": true
+  },
+  "broken_ring": {
+    "id": "broken_ring",
+    "name": "broken ring",
+    "article": "a",
+    "plural": "broken rings",
+    "emoji": " <:nypsi_broken_ring:1384749748803600405>",
+    "longDesc": "ouch...",
+    "rarity": 4,
+    "role": "collectable",
+    "in_crates": false
   },
   "radio": {
     "id": "radio",

--- a/prisma/migrations/20250618034837_marriage/migration.sql
+++ b/prisma/migrations/20250618034837_marriage/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Marriage" (
+    "userId" TEXT NOT NULL,
+    "partnerId" TEXT NOT NULL,
+    "marriageStart" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Marriage_pkey" PRIMARY KEY ("userId","partnerId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Marriage_userId_key" ON "Marriage"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Marriage_partnerId_key" ON "Marriage"("partnerId");
+
+-- AddForeignKey
+ALTER TABLE "Marriage" ADD CONSTRAINT "Marriage_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model User {
   ModerationEvidence       ModerationEvidence[]
   ChatReactionLeaderboards ChatReactionLeaderboards[]
   z                        z?
+  Marriage                 Marriage?
   Purchases                Purchases[]
   WordleGame               WordleGame[]
   FlagGame                 FlagGame[]
@@ -558,6 +559,16 @@ model Aura {
 
   @@index([recipientId])
   @@index([senderId])
+}
+
+model Marriage {
+  user      User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String @unique
+  partnerId String @unique
+
+  marriageStart DateTime @default(now())
+
+  @@id([userId, partnerId])
 }
 
 // guild specific tables

--- a/src/commands/divorce.ts
+++ b/src/commands/divorce.ts
@@ -1,0 +1,156 @@
+import {
+  ActionRowBuilder,
+  BaseMessageOptions,
+  ButtonBuilder,
+  ButtonStyle,
+  CommandInteraction,
+  Interaction,
+  InteractionEditReplyOptions,
+  InteractionReplyOptions,
+  Message,
+  MessageActionRowComponentBuilder,
+  MessageEditOptions,
+  MessageFlags,
+} from "discord.js";
+import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
+import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
+import { createUser, getItems, userExists } from "../utils/functions/economy/utils";
+import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
+import { isMarried, removeMarriage } from "../utils/functions/users/marriage";
+import { addInventoryItem } from "../utils/functions/economy/inventory";
+import { getLastKnownUsername } from "../utils/functions/users/tag";
+import { addNotificationToQueue } from "../utils/functions/users/notifications";
+
+const cmd = new Command("divorce", "divorce your partner", "fun");
+
+cmd.slashEnabled = true;
+
+async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction)) {
+  const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
+    if (!(message instanceof Message)) {
+      let usedNewMessage = false;
+      let res;
+
+      if (message.deferred) {
+        res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
+          usedNewMessage = true;
+          return await message.channel.send(data as BaseMessageOptions);
+        });
+      } else {
+        res = await message.reply(data as InteractionReplyOptions).catch(() => {
+          return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
+            usedNewMessage = true;
+            return await message.channel.send(data as BaseMessageOptions);
+          });
+        });
+      }
+
+      if (usedNewMessage && res instanceof Message) return res;
+
+      const replyMsg = await message.fetchReply();
+      if (replyMsg instanceof Message) {
+        return replyMsg;
+      }
+    } else {
+      return await message.channel.send(data as BaseMessageOptions);
+    }
+  };
+
+  const edit = async (data: MessageEditOptions, msg: Message) => {
+    if (!(message instanceof Message)) {
+      await message.editReply(data as InteractionEditReplyOptions).catch(() => {});
+      return await message.fetchReply();
+    } else {
+      return await msg.edit(data).catch(() => {});
+    }
+  };
+
+  if (await onCooldown(cmd.name, message.member)) {
+    const res = await getResponse(cmd.name, message.member);
+
+    if (res.respond) send({ embeds: [res.embed], flags: MessageFlags.Ephemeral });
+    return;
+  }
+
+  if (!(await userExists(message.member))) await createUser(message.member);
+
+  const married = await isMarried(message.member);
+
+  if (!married)
+    return send({ embeds: [new ErrorEmbed("you are not married")], flags: MessageFlags.Ephemeral });
+
+  await addCooldown(cmd.name, message.member, 30);
+
+  const partnerName = await getLastKnownUsername(married.partnerId);
+
+  const embed = new CustomEmbed(message.member)
+    .setHeader("confirm divorce")
+    .setDescription(`are you sure you want to divorce ${partnerName}?`);
+
+  const row = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+    new ButtonBuilder().setCustomId("yes").setLabel("confirm").setStyle(ButtonStyle.Danger),
+    new ButtonBuilder().setCustomId("no").setLabel("cancel").setStyle(ButtonStyle.Primary),
+  );
+
+  const msg = await send({ embeds: [embed], components: [row] });
+
+  const filter = (i: Interaction) => i.user.id == message.member.id;
+
+  if (!msg) return;
+
+  const reaction = await msg
+    .awaitMessageComponent({ filter, time: 30000 })
+    .then(async (collected) => {
+      return { res: collected.customId, interaction: collected };
+    })
+    .catch(async () => {
+      await edit(
+        {
+          components: [
+            new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+              new ButtonBuilder()
+                .setStyle(ButtonStyle.Danger)
+                .setLabel("expired")
+                .setCustomId("boobies")
+                .setDisabled(true),
+            ),
+          ],
+        },
+        msg,
+      ).catch(() => {});
+    });
+
+  if (!reaction) return edit({ embeds: [embed], components: [] }, msg);
+
+  const { res, interaction } = reaction;
+
+  if (res == "yes") {
+    interaction.deferUpdate();
+    await removeMarriage(message.member);
+    await addInventoryItem(married.partnerId, "broken_ring", 1);
+
+    embed.setDescription(`✅ you have divorced ${partnerName}`);
+
+    addNotificationToQueue({
+      memberId: married.partnerId,
+      payload: {
+        embed: new CustomEmbed(
+          married.partnerId,
+          `${getItems()["broken_ring"].emoji} you have been divorced by ${message.member.user.username}!`,
+        ).setFooter({ text: `+1 broken ring` }),
+      },
+    });
+
+    return edit({ embeds: [embed], components: [] }, msg);
+  } else {
+    interaction.reply({
+      embeds: [new CustomEmbed(message.member, "✅ cancelled")],
+      flags: MessageFlags.Ephemeral,
+    });
+    return edit({ embeds: [embed], components: [] }, msg);
+  }
+}
+
+cmd.setRun(run);
+
+module.exports = cmd;

--- a/src/commands/marry.ts
+++ b/src/commands/marry.ts
@@ -1,0 +1,241 @@
+import {
+  ActionRowBuilder,
+  BaseMessageOptions,
+  ButtonBuilder,
+  ButtonStyle,
+  CommandInteraction,
+  Interaction,
+  InteractionEditReplyOptions,
+  InteractionReplyOptions,
+  Message,
+  MessageActionRowComponentBuilder,
+  MessageEditOptions,
+  MessageFlags,
+} from "discord.js";
+import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
+import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
+import { createUser, getItems, userExists } from "../utils/functions/economy/utils";
+import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
+import { addMarriage, isMarried } from "../utils/functions/users/marriage";
+import {
+  addInventoryItem,
+  getInventory,
+  removeInventoryItem,
+} from "../utils/functions/economy/inventory";
+
+const cmd = new Command("marry", "marry your ekitten", "fun");
+
+cmd.slashEnabled = true;
+
+cmd.slashData.addUserOption((user) =>
+  user.setName("user").setDescription("who do you want to marry").setRequired(true),
+);
+
+const requesting = new Set<string>();
+const requested = new Set<string>();
+
+async function run(
+  message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction),
+  args: string[],
+) {
+  const send = async (data: BaseMessageOptions | InteractionReplyOptions) => {
+    if (!(message instanceof Message)) {
+      let usedNewMessage = false;
+      let res;
+
+      if (message.deferred) {
+        res = await message.editReply(data as InteractionEditReplyOptions).catch(async () => {
+          usedNewMessage = true;
+          return await message.channel.send(data as BaseMessageOptions);
+        });
+      } else {
+        res = await message.reply(data as InteractionReplyOptions).catch(() => {
+          return message.editReply(data as InteractionEditReplyOptions).catch(async () => {
+            usedNewMessage = true;
+            return await message.channel.send(data as BaseMessageOptions);
+          });
+        });
+      }
+
+      if (usedNewMessage && res instanceof Message) return res;
+
+      const replyMsg = await message.fetchReply();
+      if (replyMsg instanceof Message) {
+        return replyMsg;
+      }
+    } else {
+      return await message.channel.send(data as BaseMessageOptions);
+    }
+  };
+
+  const edit = async (data: MessageEditOptions, msg: Message) => {
+    if (!(message instanceof Message)) {
+      await message.editReply(data as InteractionEditReplyOptions).catch(() => {});
+      return await message.fetchReply();
+    } else {
+      return await msg.edit(data).catch(() => {});
+    }
+  };
+
+  if (await onCooldown(cmd.name, message.member)) {
+    const res = await getResponse(cmd.name, message.member);
+
+    if (res.respond) send({ embeds: [res.embed], flags: MessageFlags.Ephemeral });
+    return;
+  }
+
+  if (!(await userExists(message.member))) await createUser(message.member);
+
+  if (args.length != 1) {
+    return send({ embeds: [new ErrorEmbed("/marry <user>")] });
+  }
+
+  if (await isMarried(message.member))
+    return send({
+      embeds: [
+        new ErrorEmbed("you are already married").setFooter({
+          text: "divorce your current partner with /divorce",
+        }),
+      ],
+      flags: MessageFlags.Ephemeral,
+    });
+
+  if (!(await getInventory(message.member)).has("ring")) {
+    return send({
+      embeds: [new ErrorEmbed("you must have a ring to propose to someone")],
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  if (requesting.has(message.member.id)) {
+    return send({
+      embeds: [new ErrorEmbed("you are already proposing to someone")],
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  if (!message.mentions?.members?.first()) {
+    return send({
+      embeds: [new ErrorEmbed("you must tag the member you want to marry")],
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const target = message.mentions.members.first();
+
+  if (target.user.id == message.member.id) {
+    return send({
+      embeds: [new ErrorEmbed("you cannot marry yourself")],
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  if (requested.has(target.user.id)) {
+    return send({
+      embeds: [new ErrorEmbed("this user is currently being proposed to. wait your turn!!")],
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  if (!(await userExists(target.user.id))) {
+    return send({ embeds: [new ErrorEmbed("invalid user")], flags: MessageFlags.Ephemeral });
+  }
+
+  if (await isMarried(target)) {
+    return send({
+      embeds: [new ErrorEmbed("that user is already married")],
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  await addCooldown(cmd.name, message.member, 30);
+
+  requested.add(target.user.id);
+  requesting.add(message.member.id);
+
+  const embed = new CustomEmbed(message.member)
+    .setHeader("marriage proposal")
+    .setDescription(`do you take ${message.member.toString()} to be your lawfully wedded partner?`);
+
+  const row = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId("yes")
+      .setLabel("i do!")
+      .setStyle(ButtonStyle.Success)
+      .setEmoji(getItems()["ring"].emoji),
+    new ButtonBuilder()
+      .setCustomId("no")
+      .setLabel("run away")
+      .setStyle(ButtonStyle.Danger)
+      .setEmoji(getItems()["broken_ring"].emoji),
+  );
+
+  const msg = await send({ content: target.toString(), embeds: [embed], components: [row] }).catch(
+    () => {
+      requested.delete(target.user.id);
+      requesting.delete(message.member.id);
+    },
+  );
+
+  const filter = (i: Interaction) => i.user.id == target.user.id;
+  let fail = false;
+
+  if (!msg) return;
+
+  await removeInventoryItem(message.member, "ring", 1);
+
+  const reaction = await msg
+    .awaitMessageComponent({ filter, time: 30000 })
+    .then(async (collected) => {
+      await collected.deferUpdate();
+      return collected.customId;
+    })
+    .catch(async () => {
+      await edit(
+        {
+          components: [
+            new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+              new ButtonBuilder()
+                .setStyle(ButtonStyle.Danger)
+                .setLabel("expired")
+                .setCustomId("boobies")
+                .setDisabled(true),
+            ),
+          ],
+        },
+        msg,
+      ).catch(() => {});
+      fail = true;
+      requested.delete(target.user.id);
+      requesting.delete(message.member.id);
+      await addInventoryItem(message.member, "ring", 1);
+    });
+
+  if (fail) {
+    await addInventoryItem(message.member, "ring", 1);
+    return;
+  }
+
+  if (reaction == "yes") {
+    if (await isMarried(target)) {
+      embed.setDescription("❌ you are already married");
+    } else if (await isMarried(message.member)) {
+      embed.setDescription(`❌ ${message.member.user.username} is already married`);
+    } else {
+      await addMarriage(message.member.id, target.id);
+      embed.setDescription("you may now kiss the bride!");
+    }
+  } else {
+    await addInventoryItem(message.member, "broken_ring", 1);
+    embed.setDescription("oh. that was awkward.").setFooter({ text: `+1 broken ring` });
+  }
+
+  requested.delete(target.user.id);
+  requesting.delete(message.member.id);
+
+  return edit({ embeds: [embed], components: [] }, msg);
+}
+
+cmd.setRun(run);
+
+module.exports = cmd;

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -57,6 +57,8 @@ import { addView, getViews } from "../utils/functions/users/views";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 import { pluralize } from "../utils/functions/string";
 import { NypsiClient } from "../models/Client";
+import { isMarried } from "../utils/functions/users/marriage";
+import { getLastKnownUsername } from "../utils/functions/users/tag";
 
 const cmd = new Command("profile", "view yours or someone's nypsi profile", "money").setAliases([
   "p",
@@ -198,15 +200,20 @@ async function run(
 
     if (target.user.id == message.author.id && padlock) padlockStatus = true;
 
-    let gemLine = "";
+    let desc = "";
 
     if ((await inventory.hasGem("crystal_heart")).any)
-      gemLine += `${getItems()["crystal_heart"].emoji}`;
-    if ((await inventory.hasGem("white_gem")).any) gemLine += `${getItems()["white_gem"].emoji}`;
-    if ((await inventory.hasGem("pink_gem")).any) gemLine += `${getItems()["pink_gem"].emoji}`;
-    if ((await inventory.hasGem("purple_gem")).any) gemLine += `${getItems()["purple_gem"].emoji}`;
-    if ((await inventory.hasGem("blue_gem")).any) gemLine += `${getItems()["blue_gem"].emoji}`;
-    if ((await inventory.hasGem("green_gem")).any) gemLine += `${getItems()["green_gem"].emoji}`;
+      desc += `${getItems()["crystal_heart"].emoji}`;
+    if ((await inventory.hasGem("white_gem")).any) desc += `${getItems()["white_gem"].emoji}`;
+    if ((await inventory.hasGem("pink_gem")).any) desc += `${getItems()["pink_gem"].emoji}`;
+    if ((await inventory.hasGem("purple_gem")).any) desc += `${getItems()["purple_gem"].emoji}`;
+    if ((await inventory.hasGem("blue_gem")).any) desc += `${getItems()["blue_gem"].emoji}`;
+    if ((await inventory.hasGem("green_gem")).any) desc += `${getItems()["green_gem"].emoji}`;
+
+    const marriage = await isMarried(target);
+
+    if (marriage)
+      desc += `${desc ? "\n" : ""}${getItems()["ring"].emoji} married to **${await getLastKnownUsername(marriage.partnerId)}**`;
 
     const balanceSection =
       `${padlockStatus ? "🔒" : "💰"} $**${formatNumberPretty(balance)}**\n` +
@@ -214,7 +221,7 @@ async function run(
         net.amount > 15_000_000 ? `\n🌍 $**${formatNumberPretty(net.amount)}**` : ""
       }`;
 
-    if (gemLine) embed.setDescription(gemLine);
+    if (desc) embed.setDescription(desc);
     embed.addField("balance", balanceSection, true);
     embed.addField(
       "level",

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -59,6 +59,7 @@ export default {
         LASTFM: "cache:user:lastfm",
         TRACKING: "cache:user:tracking",
         ADMIN_LEVEL: "cache:user:adminlvl",
+        MARRIED: "cache:user:married",
         tags: "cache:user:tags",
         tagCount: "cache:tagcount",
         captcha_fail: "nypsi:user:captcha:fail",

--- a/src/utils/functions/users/marriage.ts
+++ b/src/utils/functions/users/marriage.ts
@@ -1,0 +1,45 @@
+import { GuildMember } from "discord.js";
+import { Marriage } from "@prisma/client";
+import prisma from "../../../init/database";
+
+export async function isMarried(member: GuildMember | string): Promise<false | Marriage> {
+  let userId: string;
+  if (member instanceof GuildMember) {
+    userId = member.user.id;
+  } else {
+    userId = member;
+  }
+
+  const res = await prisma.marriage.findFirst({
+    where: {
+      userId,
+    },
+  });
+
+  if (res && !(await prisma.user.findFirst({ where: { id: res.partnerId } }))) {
+    await removeMarriage(member);
+    return false;
+  }
+
+  return res || false;
+}
+
+export async function addMarriage(userId: string, targetId: string) {
+  await prisma.marriage.create({ data: { userId: userId, partnerId: targetId } });
+  await prisma.marriage.create({ data: { userId: targetId, partnerId: userId } });
+}
+
+export async function removeMarriage(member: GuildMember | string) {
+  let userId: string;
+  if (member instanceof GuildMember) {
+    userId = member.user.id;
+  } else {
+    userId = member;
+  }
+
+  await prisma.marriage.deleteMany({
+    where: {
+      OR: [{ userId }, { partnerId: userId }],
+    },
+  });
+}

--- a/src/utils/functions/users/utils.ts
+++ b/src/utils/functions/users/utils.ts
@@ -6,6 +6,7 @@ import Constants from "../../Constants";
 import { logger } from "../../logger";
 import { getGuildByUser } from "../economy/guilds";
 import { deleteOffer, getTargetedOffers } from "../economy/offers";
+import { isMarried, removeMarriage } from "./marriage";
 import { deleteImage } from "../image";
 import { deleteAllAvatars } from "./history";
 import ms = require("ms");
@@ -287,6 +288,10 @@ export async function dataDelete(userId: string) {
 
   for (const offer of offers) {
     await deleteOffer(offer);
+  }
+
+  if (await isMarried(userId)) {
+    await removeMarriage(userId);
   }
 
   await prisma.user


### PR DESCRIPTION
closes #1823

requires a ring to marry someone (is consumed on proposal) (given back if response expires)

![image](https://github.com/user-attachments/assets/793cbcb2-7dcf-48de-8199-963f16fbca7d)

if no (broken ring is given to the proposer)
![image](https://github.com/user-attachments/assets/44c38aa4-24d1-4eb2-8797-6c780842f186)

if yes
![image](https://github.com/user-attachments/assets/72adcd7e-d2e2-479d-ae11-b435f5eb4333)

when confirming divorce (ring is given to divorce target)
![image](https://github.com/user-attachments/assets/fe3f2703-b6b0-4d22-9f2d-c78879ceeb3a)
![image](https://github.com/user-attachments/assets/cd5d9de6-6816-4f69-a561-74226f72eb25)

marriage is shown in profile under gem line
![image](https://github.com/user-attachments/assets/70e81e17-6542-4e36-a8f7-c8bfe951d33a)