### PR TITLE
refactor: standardize member getters

### DIFF
--- a/src/commands/achievements.ts
+++ b/src/commands/achievements.ts
@@ -24,8 +24,8 @@ import {
 } from "../utils/functions/economy/achievements";
 import { getAchievements, getItems, getTagsData } from "../utils/functions/economy/utils";
 import PageManager from "../utils/functions/page";
-import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 import { pluralize } from "../utils/functions/string";
+import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 
 const cmd = new Command("achievements", "view your achievement progress", "money").setAliases([
   "ach",
@@ -96,7 +96,7 @@ async function run(
 
   const showCurrentProgress = async () => {
     const allAchievementData = getAchievements();
-    const achievements = await getUncompletedAchievements(message.author.id);
+    const achievements = await getUncompletedAchievements(message.member);
 
     if (!achievements || achievements.length == 0) {
       return showAllAchievements();
@@ -175,7 +175,7 @@ async function run(
   const showAllAchievements = async () => {
     const allAchievements = getAchievements();
     const achievementIds = Object.keys(allAchievements);
-    const usersAchievements = await getAllAchievements(message.author.id);
+    const usersAchievements = await getAllAchievements(message.member);
     const userAchievementIds = usersAchievements.map((i) => i.achievementId);
 
     inPlaceSort(achievementIds).asc();
@@ -286,7 +286,7 @@ async function run(
       return send({ embeds: [new ErrorEmbed("couldnt find that achievement")] });
     }
 
-    const achievement = await getUserAchievement(message.author.id, selected.id);
+    const achievement = await getUserAchievement(message.member, selected.id);
 
     const embed = new CustomEmbed(message.member).setTitle(`${selected.emoji} ${selected.name}`);
 

--- a/src/commands/alts.ts
+++ b/src/commands/alts.ts
@@ -5,7 +5,6 @@ import {
   ButtonStyle,
   CommandInteraction,
   Guild,
-  GuildMember,
   Interaction,
   InteractionEditReplyOptions,
   InteractionReplyOptions,
@@ -22,7 +21,7 @@ import Constants from "../utils/Constants";
 import { createUser, userExists } from "../utils/functions/economy/utils";
 import { isAltPunish } from "../utils/functions/guilds/altpunish";
 import { getPrefix } from "../utils/functions/guilds/utils";
-import { getMember } from "../utils/functions/member";
+import { getMember, MemberResolvable } from "../utils/functions/member";
 import {
   addAlt,
   deleteAlt,
@@ -392,10 +391,8 @@ async function getRow(
   return row;
 }
 
-async function getUserAlts(guild: Guild, member: GuildMember | string) {
-  return await getAlts(guild, member instanceof GuildMember ? member.user.id : member).catch(
-    () => [] as string[],
-  );
+async function getUserAlts(guild: Guild, member: MemberResolvable) {
+  return await getAlts(guild, member).catch(() => [] as string[]);
 }
 
 cmd.setRun(run);

--- a/src/commands/ass.ts
+++ b/src/commands/ass.ts
@@ -113,7 +113,7 @@ async function run(
 
   send({ embeds: [embed] });
 
-  addProgress(message.author.id, "unsure", 1);
+  addProgress(message.member, "unsure", 1);
 }
 
 cmd.setRun(run);

--- a/src/commands/avatarhistory.ts
+++ b/src/commands/avatarhistory.ts
@@ -71,8 +71,8 @@ async function run(
 
   if (history.length == 0) {
     if (
-      (await isTracking(message.author.id)) &&
-      !(await isEcoBanned(message.author.id)
+      (await isTracking(message.member)) &&
+      !(await isEcoBanned(message.member)
         .then((r) => r.banned)
         .catch(() => false))
     ) {
@@ -98,7 +98,7 @@ async function run(
           );
         });
 
-      await addNewAvatar(message.author.id, `https://cdn.nypsi.xyz/${key}`);
+      await addNewAvatar(message.member, `https://cdn.nypsi.xyz/${key}`);
       logger.debug(`uploaded new avatar for ${message.author.id}`);
 
       history = await fetchAvatarHistory(message.member);
@@ -166,7 +166,7 @@ async function run(
         const res = await deleteAvatar(history[manager.currentPage - 1].id);
 
         if (res) {
-          history = await fetchAvatarHistory(message.author.id);
+          history = await fetchAvatarHistory(message.member);
           manager.pages = PageManager.createPages(history, 1);
           manager.lastPage = manager.pages.size;
 

--- a/src/commands/balance.ts
+++ b/src/commands/balance.ts
@@ -8,6 +8,7 @@ import {
   MessageFlags,
 } from "discord.js";
 import prisma from "../init/database";
+import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
 import Constants from "../utils/Constants.js";
@@ -22,11 +23,10 @@ import {
 import { getInventory } from "../utils/functions/economy/inventory";
 import { getLevel, getPrestige } from "../utils/functions/economy/levelling.js";
 import { createUser, deleteUser, getItems, userExists } from "../utils/functions/economy/utils.js";
-import { getMember } from "../utils/functions/member.js";
+import { getMember, getUserId } from "../utils/functions/member.js";
 import { getNypsiBankBalance, getTax, getTaxRefreshTime } from "../utils/functions/tax.js";
 import { addView } from "../utils/functions/users/views";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
-import { NypsiClient } from "../models/Client";
 
 const cmd = new Command("balance", "check your balance", "money").setAliases([
   "bal",
@@ -60,7 +60,7 @@ async function run(
     } else if (args[1] == "clearinv") {
       await prisma.inventory.deleteMany({
         where: {
-          userId: typeof target == "string" ? target : target.user.id,
+          userId: getUserId(target),
         },
       });
 
@@ -192,7 +192,7 @@ async function run(
 
   send({ embeds: [embed] });
 
-  addView(target.user.id, message.author.id, `balance in ${message.guild.id}`);
+  addView(target, message.member, `balance in ${message.guild.id}`);
 }
 
 cmd.setRun(run);

--- a/src/commands/bankrob.ts
+++ b/src/commands/bankrob.ts
@@ -166,8 +166,8 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
 
       await Promise.all([
         addBalance(message.member, stolen),
-        addProgress(message.author.id, "robber", 1),
-        addTaskProgress(message.author.id, "thief"),
+        addProgress(message.member, "robber", 1),
+        addTaskProgress(message.member, "thief"),
       ]);
 
       await removeFromNypsiBankBalance(stolen);

--- a/src/commands/banned.ts
+++ b/src/commands/banned.ts
@@ -3,9 +3,9 @@ import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Comman
 import { CustomEmbed } from "../models/EmbedBuilders";
 import { getBannedUsers } from "../utils/functions/moderation/ban";
 
+import PageManager from "../utils/functions/page";
 import { getLastKnownUsername } from "../utils/functions/users/tag";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
-import PageManager from "../utils/functions/page";
 
 const cmd = new Command(
   "banned",

--- a/src/commands/birthday.ts
+++ b/src/commands/birthday.ts
@@ -131,7 +131,7 @@ async function run(
     if (message.author.createdTimestamp > Date.now() - ms("30 days"))
       return send({ embeds: [new ErrorEmbed("your account is too new to use this feature ☹️")] });
 
-    const birthdayCheck = await getBirthday(message.author.id);
+    const birthdayCheck = await getBirthday(message.member);
 
     if (birthdayCheck)
       return send({
@@ -171,7 +171,7 @@ async function run(
     if (!interaction) return;
 
     if (interaction.customId === "confirm") {
-      await setBirthday(message.author.id, birthday);
+      await setBirthday(message.member, birthday);
 
       interaction.update({
         embeds: [
@@ -187,9 +187,9 @@ async function run(
       interaction.update({ components: [row] });
     }
   } else if (args[0]?.toLowerCase() === "toggle") {
-    const current = await isBirthdayEnabled(message.author.id);
+    const current = await isBirthdayEnabled(message.member);
 
-    await setBirthdayEnabled(message.author.id, !current);
+    await setBirthdayEnabled(message.member, !current);
 
     return send({
       embeds: [
@@ -328,7 +328,7 @@ async function run(
     manager.listen();
     return;
   } else {
-    const birthday = await getBirthday(message.author.id);
+    const birthday = await getBirthday(message.member);
 
     const embed = new CustomEmbed(
       message.member,

--- a/src/commands/blackjack.ts
+++ b/src/commands/blackjack.ts
@@ -48,11 +48,11 @@ import { addXp, calcEarnedGambleXp } from "../utils/functions/economy/xp";
 import { getTier, isPremium } from "../utils/functions/premium/premium";
 import { percentChance, shuffle } from "../utils/functions/random";
 import sleep from "../utils/functions/sleep";
+import { getAdminLevel } from "../utils/functions/users/admin";
 import { recentCommands } from "../utils/functions/users/commands";
 import { addHourlyCommand } from "../utils/handlers/commandhandler";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler.js";
 import { gamble, getTimestamp, logger } from "../utils/logger";
-import { getAdminLevel } from "../utils/functions/users/admin";
 
 const cmd = new Command("blackjack", "play blackjack", "money").setAliases(["bj", "blowjob"]);
 
@@ -416,7 +416,7 @@ class Game {
   ) {
     const embed = new CustomEmbed(
       this.member,
-      await renderGambleScreen(this.member.user.id, state, this.bet, null, winnings, multi),
+      await renderGambleScreen(state, this.bet, null, winnings, multi),
     ).setHeader("blackjack", this.member.avatarURL() || this.member.user.avatarURL());
 
     if (state === "win") embed.setColor(Constants.EMBED_SUCCESS_COLOR);
@@ -446,8 +446,8 @@ class Game {
 
       if (this.hand.cards.length === 2 && this.hand.total() === 21) {
         winnings = this.bet * 2.5;
-        addProgress(this.member.user.id, "blackjack_pro", 1);
-        addTaskProgress(this.member.user.id, "blackjack");
+        addProgress(this.member, "blackjack_pro", 1);
+        addTaskProgress(this.member, "blackjack");
       }
 
       winnings = winnings + Math.floor(winnings * multi.multi);
@@ -503,7 +503,7 @@ class Game {
       percentChance(0.05) &&
       parseInt(await redis.get(`anticheat:interactivegame:count:${this.member.user.id}`)) > 100
     ) {
-      const res = await giveCaptcha(this.member.user.id);
+      const res = await giveCaptcha(this.member);
 
       if (res) {
         logger.info(
@@ -551,7 +551,7 @@ class Game {
       logger.info(
         `::cmd ${this.message.guild.id} ${this.message.channelId} ${this.member.user.username}: replaying blackjack`,
       );
-      if (await isLockedOut(this.member.user.id)) return verifyUser(this.playerMessage);
+      if (await isLockedOut(this.member)) return verifyUser(this.playerMessage);
 
       addHourlyCommand(this.member);
 

--- a/src/commands/boob.ts
+++ b/src/commands/boob.ts
@@ -120,7 +120,7 @@ async function run(
 
   send({ embeds: [embed] });
 
-  addProgress(message.author.id, "unsure", 1);
+  addProgress(message.member, "unsure", 1);
 }
 
 cmd.setRun(run);

--- a/src/commands/buy.ts
+++ b/src/commands/buy.ts
@@ -211,7 +211,7 @@ async function run(
   await addCooldown(cmd.name, message.member, 5);
 
   await removeBalance(message.member, selected.buy * amount);
-  addStat(message.author.id, "spent-shop", selected.buy * amount);
+  addStat(message.member, "spent-shop", selected.buy * amount);
   await addInventoryItem(message.member, selected.id, amount);
 
   const embed = new CustomEmbed(

--- a/src/commands/captchatest.ts
+++ b/src/commands/captchatest.ts
@@ -1,12 +1,12 @@
 import { CommandInteraction, Message } from "discord.js";
+import prisma from "../init/database";
+import redis from "../init/redis";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
+import Constants from "../utils/Constants";
 import { giveCaptcha, isLockedOut, passedCaptcha } from "../utils/functions/captcha";
+import { getMember } from "../utils/functions/member";
 import { getAdminLevel } from "../utils/functions/users/admin";
 import { logger } from "../utils/logger";
-import { getMember } from "../utils/functions/member";
-import redis from "../init/redis";
-import Constants from "../utils/Constants";
-import prisma from "../init/database";
 
 const cmd = new Command("captchatest", "test an account", "none");
 
@@ -14,7 +14,7 @@ async function run(
   message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction),
   args: string[],
 ) {
-  if ((await getAdminLevel(message.author.id)) < 1) return;
+  if ((await getAdminLevel(message.member)) < 1) return;
 
   if (args.length == 0) {
     return message.channel.send({ content: "dumbass" });
@@ -28,7 +28,7 @@ async function run(
       return;
     }
 
-    const res = await isLockedOut(target.id);
+    const res = await isLockedOut(target);
 
     if (!res) {
       if (message instanceof Message) message.react("➖");

--- a/src/commands/capybara.ts
+++ b/src/commands/capybara.ts
@@ -72,7 +72,7 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
 
   send({ embeds: [embed] });
 
-  addProgress(message.author.id, "cute", 1);
+  addProgress(message.member, "cute", 1);
 }
 
 cmd.setRun(run);

--- a/src/commands/cat.ts
+++ b/src/commands/cat.ts
@@ -77,8 +77,8 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
 
   send({ embeds: [embed] });
 
-  addProgress(message.author.id, "cute", 1);
-  addTaskProgress(message.author.id, "cats_daily");
+  addProgress(message.member, "cute", 1);
+  addTaskProgress(message.member, "cats_daily");
 }
 
 cmd.setRun(run);

--- a/src/commands/chatreaction.ts
+++ b/src/commands/chatreaction.ts
@@ -630,7 +630,7 @@ async function run(
           embeds: [new ErrorEmbed("that user is blacklisted from chat reactions in this server")],
         });
 
-      if (!(await userExists(target.user.id))) await createUser(target.user.id);
+      if (!(await userExists(target))) await createUser(target);
 
       let wager = formatNumber(args[2] || 0);
 
@@ -638,16 +638,16 @@ async function run(
       if (!wager) wager = 0;
       if (isNaN(wager)) wager = 0;
 
-      if (!(await getPreferences(target.user.id)).duelRequests) {
+      if (!(await getPreferences(target)).duelRequests) {
         return send({
           embeds: [new ErrorEmbed(`${target.user.toString()} has requests disabled`)],
         });
       }
 
-      if ((await isEcoBanned(message.author.id)).banned && wager > 0)
+      if ((await isEcoBanned(message.member)).banned && wager > 0)
         return send({ embeds: [new ErrorEmbed("you are banned. lol.")] });
 
-      if ((await isEcoBanned(target.user.id)).banned && wager > 0)
+      if ((await isEcoBanned(target)).banned && wager > 0)
         return send({ embeds: [new ErrorEmbed("they are banned. lol.")] });
 
       if ((await getBalance(message.member)) < wager)
@@ -747,7 +747,7 @@ async function run(
       if (!wager) wager = 0;
       if (isNaN(wager)) wager = 0;
 
-      if ((await isEcoBanned(message.author.id)).banned && wager > 0)
+      if ((await isEcoBanned(message.member)).banned && wager > 0)
         return send({ embeds: [new ErrorEmbed("you are banned. lol.")] });
 
       if ((await getBalance(message.member)) < wager)
@@ -790,14 +790,14 @@ async function run(
       const filter = async (i: Interaction): Promise<boolean> => {
         if (i.user.id != message.author.id && (i as ButtonInteraction).customId == "n")
           return false;
-        if ((await isEcoBanned(i.user.id)).banned && wager > 0) return false;
+        if ((await isEcoBanned(i.user)).banned && wager > 0) return false;
 
         if (i.user.id === message.author.id) {
           if ((i as ButtonInteraction).customId === "n") return true;
           return false;
         }
 
-        if (!(await userExists(i.user.id)) || (await getBalance(i.user.id)) < wager) {
+        if (!(await userExists(i.user)) || (await getBalance(i.user)) < wager) {
           if (i.isRepliable())
             await i.reply({
               flags: MessageFlags.Ephemeral,
@@ -806,13 +806,13 @@ async function run(
           return false;
         }
 
-        if ((await calcMaxBet(i.user.id)) * 10 < wager) {
+        if ((await calcMaxBet(i.user)) * 10 < wager) {
           if (i.isRepliable())
             i.reply({
               flags: MessageFlags.Ephemeral,
               embeds: [
                 new ErrorEmbed(
-                  `your max bet is $**${((await calcMaxBet(i.user.id)) * 10).toLocaleString()}**`,
+                  `your max bet is $**${((await calcMaxBet(i.user)) * 10).toLocaleString()}**`,
                 ),
               ],
             });
@@ -1112,7 +1112,7 @@ async function run(
         let added = false;
         let max = 1;
 
-        if (await isPremium(message.author.id)) {
+        if (await isPremium(message.member)) {
           max = 5;
         }
 
@@ -1278,7 +1278,7 @@ async function run(
 
       let maxSize = 100;
 
-      if (await isPremium(message.author.id)) {
+      if (await isPremium(message.member)) {
         maxSize = 200;
       }
 

--- a/src/commands/cmdwatch.ts
+++ b/src/commands/cmdwatch.ts
@@ -1,16 +1,16 @@
 import { CommandInteraction, Message } from "discord.js";
 import redis from "../init/redis";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
-import Constants from "../utils/Constants";
-import { getAdminLevel } from "../utils/functions/users/admin";
-import { logger } from "../utils/logger";
-import { userExists } from "../utils/functions/economy/utils";
 import { ErrorEmbed } from "../models/EmbedBuilders";
+import Constants from "../utils/Constants";
+import { userExists } from "../utils/functions/economy/utils";
+import { getAdminLevel } from "../utils/functions/users/admin";
 import {
   commandAliasExists,
   commandExists,
   getCommandFromAlias,
 } from "../utils/handlers/commandhandler";
+import { logger } from "../utils/logger";
 
 const cmd = new Command("cmdwatch", "watch commands", "none");
 
@@ -18,7 +18,7 @@ async function run(
   message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction),
   args: string[],
 ) {
-  if ((await getAdminLevel(message.author.id)) < 2) return;
+  if ((await getAdminLevel(message.member)) < 2) return;
 
   if (args.length < 2) {
     return message.channel.send({ content: "dumbass - $cmdwatch <userid> <cmd>" });

--- a/src/commands/coinflip.ts
+++ b/src/commands/coinflip.ts
@@ -118,7 +118,7 @@ async function run(
 
     if (type === "money") {
       if (bet > (await getBalance(player2))) {
-        await addBalance(player1.user.id, bet);
+        await addBalance(player1.user, bet);
         return response.editReply({
           embeds: [new ErrorEmbed(`${player2.user.toString()} cannot afford this bet`)],
         });
@@ -205,7 +205,7 @@ async function run(
       let winnings = bet * 2;
       let tax = 0;
 
-      if (winnings > 1_000_000 && !(await isPremium(winner.user.id))) {
+      if (winnings > 1_000_000 && !(await isPremium(winner))) {
         tax = await getTax();
 
         const taxed = Math.floor(winnings * tax);
@@ -359,7 +359,7 @@ async function run(
       return send({ embeds: [new ErrorEmbed("invalid user")] });
     }
 
-    if (!(await getPreferences(target.user.id)).duelRequests) {
+    if (!(await getPreferences(target)).duelRequests) {
       return send({ embeds: [new ErrorEmbed(`${target.user.toString()} has requests disabled`)] });
     }
 
@@ -368,7 +368,7 @@ async function run(
         embeds: [new ErrorEmbed("this user is waiting for a response on a coinflip")],
       });
 
-    if ((await isEcoBanned(target.user.id)).banned) {
+    if ((await isEcoBanned(target)).banned) {
       return send({ embeds: [new ErrorEmbed("they are banned. lol.")] });
     }
 
@@ -418,7 +418,7 @@ async function run(
 
         if (!interaction) return;
 
-        if ((await getBalance(message.author.id)) < bet)
+        if ((await getBalance(message.member)) < bet)
           return interaction.reply({ embeds: [new ErrorEmbed("nice try buddy")] });
 
         if (interaction.customId !== "y") {
@@ -438,7 +438,7 @@ async function run(
         }** has challenged you to a coinflip\n\n**bet** $${bet.toLocaleString()}\n\ndo you accept?`,
       );
     } else {
-      const userInventory = await getInventory(message.author.id);
+      const userInventory = await getInventory(message.member);
       const targetInventory = await getInventory(target);
 
       if (userInventory.count(item.id) < itemAmount) {
@@ -521,11 +521,11 @@ async function run(
       if (i.customId == "n") return true;
 
       if (bet) {
-        const maxBet = await calcMaxBet(i.user.id);
+        const maxBet = await calcMaxBet(i.user);
 
         if (bet > maxBet * 10) {
           const confirmEmbed = new CustomEmbed(
-            i.user.id,
+            i.user,
             `are you sure you want to accept? the bet is $**${bet.toLocaleString()}**`,
           );
 
@@ -550,7 +550,7 @@ async function run(
 
           if (!confirmInteraction) return false;
 
-          if ((await getBalance(i.user.id)) < bet) {
+          if ((await getBalance(i.user)) < bet) {
             if (confirmInteraction.isRepliable())
               confirmInteraction.reply({
                 embeds: [new ErrorEmbed("you cannot afford this bet")],
@@ -682,7 +682,7 @@ async function run(
 
         if (!interaction) return;
 
-        if ((await getBalance(message.author.id)) < bet)
+        if ((await getBalance(message.member)) < bet)
           return interaction.reply({ embeds: [new ErrorEmbed("nice try buddy")] });
 
         if (interaction.customId !== "y") {
@@ -703,7 +703,7 @@ async function run(
         }** has created an open coinflip\n\n**bet** $${bet.toLocaleString()}`,
       );
     } else {
-      const userInventory = await getInventory(message.author.id);
+      const userInventory = await getInventory(message.member);
 
       if (userInventory.count(item.id) < itemAmount) {
         return send({
@@ -752,7 +752,7 @@ async function run(
         if (i.customId === "n") return true;
         return false;
       }
-      if ((await isEcoBanned(i.user.id)).banned) return false;
+      if ((await isEcoBanned(i.user)).banned) return false;
 
       if (playing.has(i.user.id)) {
         i.reply({
@@ -767,7 +767,7 @@ async function run(
         return false;
       }
 
-      if (!(await userExists(i.user.id))) {
+      if (!(await userExists(i.user))) {
         if (i.isRepliable())
           await i.reply({
             flags: MessageFlags.Ephemeral,
@@ -777,7 +777,7 @@ async function run(
       }
 
       if (bet) {
-        if ((await getBalance(i.user.id)) < bet) {
+        if ((await getBalance(i.user)) < bet) {
           if (i.isRepliable())
             i.reply({
               embeds: [new ErrorEmbed("you cannot afford this bet")],
@@ -786,11 +786,11 @@ async function run(
           return false;
         }
 
-        const maxBet = await calcMaxBet(i.user.id);
+        const maxBet = await calcMaxBet(i.user);
 
         if (bet > maxBet * 10) {
           const confirmEmbed = new CustomEmbed(
-            i.user.id,
+            i.user,
             `are you sure you want to accept? the bet is $**${bet.toLocaleString()}**`,
           );
 
@@ -815,7 +815,7 @@ async function run(
 
           if (!confirmInteraction) return false;
 
-          if ((await getBalance(i.user.id)) < bet) {
+          if ((await getBalance(i.user)) < bet) {
             if (confirmInteraction.isRepliable())
               confirmInteraction.reply({
                 embeds: [new ErrorEmbed("you cannot afford this bet")],
@@ -833,7 +833,7 @@ async function run(
           }
         }
       } else {
-        const inventory = await getInventory(i.user.id);
+        const inventory = await getInventory(i.user);
 
         if (inventory.count(item.id) < itemAmount) {
           if (i.isRepliable())

--- a/src/commands/countdown.ts
+++ b/src/commands/countdown.ts
@@ -50,8 +50,8 @@ async function run(
 
     let max = 1;
 
-    if (await isPremium(message.author.id)) {
-      max += await getTier(message.author.id);
+    if (await isPremium(message.member)) {
+      max += await getTier(message.member);
     }
 
     if (countdowns.length >= max) {

--- a/src/commands/craft.ts
+++ b/src/commands/craft.ts
@@ -24,8 +24,8 @@ import {
 import { addStat } from "../utils/functions/economy/stats";
 import { createUser, getItems, userExists } from "../utils/functions/economy/utils";
 import { getTier, isPremium } from "../utils/functions/premium/premium";
-import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 import { pluralize } from "../utils/functions/string";
+import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 
 const cmd = new Command("craft", "craft items", "money");
 

--- a/src/commands/crateall.ts
+++ b/src/commands/crateall.ts
@@ -4,8 +4,8 @@ import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
 import Constants from "../utils/Constants";
 import { addInventoryItem } from "../utils/functions/economy/inventory";
 import { getItems, userExists } from "../utils/functions/economy/utils";
-import { logger } from "../utils/logger";
 import { pluralize } from "../utils/functions/string";
+import { logger } from "../utils/logger";
 
 const cmd = new Command(
   "crateall",

--- a/src/commands/createpalette.ts
+++ b/src/commands/createpalette.ts
@@ -25,7 +25,7 @@ async function run(
     return;
   }
 
-  if (!(await isPremium(message.author.id))) {
+  if (!(await isPremium(message.member))) {
     return message.channel.send({
       embeds: [
         new ErrorEmbed("you must be have a premium membership for this command").setFooter({

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -90,7 +90,7 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
     await redis.set(Constants.redis.nypsi.GEM_GIVEN, "t", "EX", 86400);
     logger.info(`${message.author.id} received blue_gem randomly (daily)`);
     await addInventoryItem(message.member, "blue_gem", 1);
-    addProgress(message.author.id, "gem_hunter", 1);
+    addProgress(message.member, "gem_hunter", 1);
 
     if ((await getDmSettings(message.member)).other) {
       addNotificationToQueue({

--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -330,7 +330,7 @@ async function run(
 
       await m.edit({ embeds: [embed], components: [] });
 
-      await dataDelete(message.author.id);
+      await dataDelete(message.member);
 
       await addCooldown(cmd.name + "_delete", message.member, Math.floor(ms("1 week") / 1000));
 

--- a/src/commands/delp.ts
+++ b/src/commands/delp.ts
@@ -18,8 +18,8 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
 
   let amount = 25;
 
-  if (await isPremium(message.author.id)) {
-    if ((await getTier(message.author.id)) == 4) {
+  if (await isPremium(message.member)) {
+    if ((await getTier(message.member)) == 4) {
       amount = 100;
     } else {
       amount = 50;

--- a/src/commands/divorce.ts
+++ b/src/commands/divorce.ts
@@ -14,12 +14,12 @@ import {
 } from "discord.js";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
-import { createUser, getItems, userExists } from "../utils/functions/economy/utils";
-import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
-import { isMarried, removeMarriage } from "../utils/functions/users/marriage";
 import { addInventoryItem } from "../utils/functions/economy/inventory";
-import { getLastKnownUsername } from "../utils/functions/users/tag";
+import { createUser, getItems, userExists } from "../utils/functions/economy/utils";
+import { isMarried, removeMarriage } from "../utils/functions/users/marriage";
 import { addNotificationToQueue } from "../utils/functions/users/notifications";
+import { getLastKnownUsername } from "../utils/functions/users/tag";
+import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 
 const cmd = new Command("divorce", "divorce your partner", "fun");
 

--- a/src/commands/dog.ts
+++ b/src/commands/dog.ts
@@ -73,8 +73,8 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
 
   send({ embeds: [embed] });
 
-  addProgress(message.author.id, "cute", 1);
-  addTaskProgress(message.author.id, "dogs_daily");
+  addProgress(message.member, "cute", 1);
+  addTaskProgress(message.member, "dogs_daily");
 }
 
 cmd.setRun(run);

--- a/src/commands/ecoban.ts
+++ b/src/commands/ecoban.ts
@@ -10,7 +10,7 @@ async function run(
   message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction),
   args: string[],
 ) {
-  if ((await getAdminLevel(message.author.id)) < 2) return;
+  if ((await getAdminLevel(message.member)) < 2) return;
 
   if (args.length == 0) {
     return message.channel.send({ content: "dumbass" });

--- a/src/commands/f.ts
+++ b/src/commands/f.ts
@@ -8,8 +8,8 @@ import {
 } from "discord.js";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
-import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 import { pluralize } from "../utils/functions/string";
+import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 
 const cmd = new Command("f", "pay your respects", "fun");
 

--- a/src/commands/farm.ts
+++ b/src/commands/farm.ts
@@ -32,8 +32,8 @@ import {
   getPlantUpgrades,
   userExists,
 } from "../utils/functions/economy/utils";
-import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 import { pluralize } from "../utils/functions/string";
+import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 import dayjs = require("dayjs");
 
 const cmd = new Command("farm", "view your farms and harvest", "money").setAliases(["fields"]);
@@ -455,7 +455,7 @@ async function run(
 
     await addCooldown(cmd.name + "_water", message.member, 3600);
 
-    const res = await waterFarm(message.author.id);
+    const res = await waterFarm(message.member);
 
     if (res.count === 0) {
       return send({
@@ -480,7 +480,7 @@ async function run(
   } else if (args[0].toLowerCase() === "fertilise") {
     if (farms.length === 0) return send({ embeds: [new ErrorEmbed("you have no plants")] });
 
-    const res = await fertiliseFarm(message.author.id);
+    const res = await fertiliseFarm(message.member);
 
     if (res.msg === "no fertiliser") {
       return send({

--- a/src/commands/fight.ts
+++ b/src/commands/fight.ts
@@ -467,15 +467,15 @@ class Fight {
       this.updateLog(`${loser.user.username} died`);
     }
 
-    if (await userExists(winner.member.user.id)) {
-      addProgress(winner.member.user.id, "fighter", 1);
-      await addTaskProgress(winner.member.user.id, "mike_tyson");
-      addTaskProgress(winner.member.user.id, "mike_tyson_daily");
+    if (await userExists(winner.member)) {
+      addProgress(winner.member, "fighter", 1);
+      await addTaskProgress(winner.member, "mike_tyson");
+      addTaskProgress(winner.member, "mike_tyson_daily");
       await addInventoryItem(winner.member, "cookie", 1);
       embed.setFooter({ text: "well done. enjoy this cookie 🍪" });
     }
 
-    if (await userExists(this.home.user.id)) {
+    if (await userExists(this.home)) {
       await createGame({
         userId: this.home.user.id,
         bet: 0,

--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -18,10 +18,10 @@ import { getXp } from "../utils/functions/economy/xp";
 import { getPeaks } from "../utils/functions/guilds/utils";
 import { getKarma } from "../utils/functions/karma/karma";
 import { getTier, isPremium, levelString } from "../utils/functions/premium/premium";
+import { getAdminLevel } from "../utils/functions/users/admin";
 import { getLastCommand } from "../utils/functions/users/commands";
 import { fetchUsernameHistory } from "../utils/functions/users/history";
 import dayjs = require("dayjs");
-import { getAdminLevel } from "../utils/functions/users/admin";
 
 const cmd = new Command("find", "find info", "none").setPermissions(["bot owner"]);
 
@@ -199,41 +199,41 @@ async function showUser(message: NypsiMessage, user: User) {
     .setTitle(user.username)
     .setDescription(
       `\`${user.id}\`${
-        (await isPremium(user.id)) ? ` (${levelString(await getTier(user.id))}) ` : ""
-      } ${(await isEcoBanned(user.id)).banned ? "[banned]" : ""}`,
+        (await isPremium(user)) ? ` (${levelString(await getTier(user))}) ` : ""
+      } ${(await isEcoBanned(user)).banned ? "[banned]" : ""}`,
     )
     .addField(
       "user",
       `**tag** ${user.username}
             **created** ${formatDate(user.createdAt)}${
-              (await getLastCommand(user.id))
+              (await getLastCommand(user))
                 ? `\n**last command** <t:${Math.floor(
-                    (await getLastCommand(user.id)).getTime() / 1000,
+                    (await getLastCommand(user)).getTime() / 1000,
                   )}:R>`
                 : ""
             }`,
       true,
     )
-    .setFooter({ text: `${await getKarma(user.id)} karma` });
+    .setFooter({ text: `${await getKarma(user)} karma` });
 
-  if (await userExists(user.id)) {
-    const voted = await hasVoted(user.id);
+  if (await userExists(user)) {
+    const voted = await hasVoted(user);
     embed.addField(
       "economy",
-      `💰 $**${(await getBalance(user.id)).toLocaleString()}**
-            💳 $**${(await getBankBalance(user.id)).toLocaleString()}** / $**${(
-              await getMaxBankBalance(user.id)
+      `💰 $**${(await getBalance(user)).toLocaleString()}**
+            💳 $**${(await getBankBalance(user)).toLocaleString()}** / $**${(
+              await getMaxBankBalance(user)
             ).toLocaleString()}**
-      🌍 $**${(await calcNetWorth("find", user.id, user.client as NypsiClient)).amount.toLocaleString()}**
-            **xp** ${(await getXp(user.id)).toLocaleString()}
+      🌍 $**${(await calcNetWorth("find", user, user.client as NypsiClient)).amount.toLocaleString()}**
+            **xp** ${(await getXp(user)).toLocaleString()}
             **voted** ${voted}
-            **prestige** ${await getPrestige(user.id)}
+            **prestige** ${await getPrestige(user)}
             **bonus** ${Math.floor((await getGambleMulti(message.member, message.client as NypsiClient)).multi * 100)}%`,
       true,
     );
   }
 
-  const usernameHistory = await fetchUsernameHistory(user.id);
+  const usernameHistory = await fetchUsernameHistory(user);
 
   if (usernameHistory.length > 0) {
     let msg = "";

--- a/src/commands/fish.ts
+++ b/src/commands/fish.ts
@@ -11,6 +11,7 @@ import {
   MessageActionRowComponentBuilder,
   MessageFlags,
 } from "discord.js";
+import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
 import { addProgress } from "../utils/functions/economy/achievements";
@@ -30,7 +31,6 @@ import { createUser, getItems, userExists } from "../utils/functions/economy/uti
 import { addXp, calcEarnedHFMXp } from "../utils/functions/economy/xp";
 import { percentChance } from "../utils/functions/random";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
-import { NypsiClient } from "../models/Client";
 
 const cmd = new Command("fish", "go to a pond and fish", "money");
 
@@ -187,13 +187,13 @@ async function doFish(
 
   if ((await inventory.hasGem("purple_gem")).any) {
     if (percentChance(0.2)) {
-      gemBreak(message.member.user.id, 0.03, "purple_gem", message.client as NypsiClient);
+      gemBreak(message.member, 0.03, "purple_gem", message.client as NypsiClient);
       times++;
     }
   }
   if ((await inventory.hasGem("white_gem")).any) {
     if (percentChance(0.2)) {
-      gemBreak(message.member.user.id, 0.03, "white_gem", message.client as NypsiClient);
+      gemBreak(message.member, 0.03, "white_gem", message.client as NypsiClient);
       times++;
     }
   }
@@ -340,7 +340,7 @@ async function doFish(
 
       await addInventoryItem(member, chosen, amount);
 
-      if (isGem(chosen)) await addProgress(member.id, "gem_hunter", amount);
+      if (isGem(chosen)) await addProgress(member, "gem_hunter", amount);
 
       foundItems.set(chosen, foundItems.has(chosen) ? foundItems.get(chosen) + amount : amount);
     }
@@ -383,9 +383,9 @@ async function doFish(
 
   send({ embeds: [embed], components: [row] });
 
-  addProgress(message.member.user.id, "fisher", total);
-  await addTaskProgress(message.member.user.id, "fish_daily");
-  await addTaskProgress(message.member.user.id, "fish_weekly");
+  addProgress(message.member, "fisher", total);
+  await addTaskProgress(message.member, "fish_daily");
+  await addTaskProgress(message.member, "fish_weekly");
 }
 
 cmd.setRun(run);

--- a/src/commands/freemoney.ts
+++ b/src/commands/freemoney.ts
@@ -27,20 +27,20 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
 
   let amount = 1000;
 
-  if (await isPremium(message.author.id)) {
-    if ((await getTier(message.author.id)) == 1) {
+  if (await isPremium(message.member)) {
+    if ((await getTier(message.member)) == 1) {
       amount = 2500;
-    } else if ((await getTier(message.author.id)) == 2) {
+    } else if ((await getTier(message.member)) == 2) {
       amount = 5000;
-    } else if ((await getTier(message.author.id)) == 3) {
+    } else if ((await getTier(message.member)) == 3) {
       amount = 7500;
-    } else if ((await getTier(message.author.id)) == 4) {
+    } else if ((await getTier(message.member)) == 4) {
       amount = 10000;
     }
   }
 
   await addBalance(message.member, amount);
-  addStat(message.author.id, "earned-freemoney", amount);
+  addStat(message.member, "earned-freemoney", amount);
 
   const embed = new CustomEmbed(message.member, `+$**${amount.toLocaleString()}**`).setHeader(
     "free money",

--- a/src/commands/furry.ts
+++ b/src/commands/furry.ts
@@ -145,7 +145,7 @@ async function run(
 
   await send({ embeds: [embed] });
 
-  addProgress(message.author.id, "unsure", 1);
+  addProgress(message.member, "unsure", 1);
 }
 
 cmd.setRun(run);

--- a/src/commands/garage.ts
+++ b/src/commands/garage.ts
@@ -89,7 +89,7 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
     interaction?: ButtonInteraction | StringSelectMenuInteraction,
     needsUpdate = true,
   ): Promise<any> => {
-    const inventory = await getInventory(message.author.id);
+    const inventory = await getInventory(message.member);
     const embed = new CustomEmbed(message.member).setHeader(
       `${message.author.username}'s garage`,
       message.author.avatarURL(),
@@ -230,11 +230,11 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
         } else if (interaction.customId === "skin") {
           const chosen = interaction.values[0];
 
-          await setSkin(message.author.id, cars[index].id, chosen === "none" ? undefined : chosen);
+          await setSkin(message.member, cars[index].id, chosen === "none" ? undefined : chosen);
 
-          const changed = await checkSkins(message.author.id, await getGarage(message.author.id));
+          const changed = await checkSkins(message.member, await getGarage(message.member));
 
-          showCars(await getGarage(message.author.id), index, msg, interaction, true);
+          showCars(await getGarage(message.member), index, msg, interaction, true);
 
           if (changed) {
             await sleep(1000);
@@ -253,8 +253,8 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
         }
       } else if (interaction.componentType === ComponentType.Button) {
         if (interaction.customId === "buy") {
-          const balance = await getBalance(message.author.id);
-          const cost = calcCarCost((await getGarage(message.author.id)).length);
+          const balance = await getBalance(message.member);
+          const cost = calcCarCost((await getGarage(message.member)).length);
 
           if (balance < cost) {
             await interaction.reply({
@@ -264,10 +264,10 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
             return showCars(cars, index, msg, undefined, false);
           }
 
-          await addCar(message.author.id);
-          await removeBalance(message.author.id, cost);
-          addStat(message.author.id, "spent-garage", cost);
-          return showCars(await getGarage(message.author.id), index, msg, interaction);
+          await addCar(message.member);
+          await removeBalance(message.member, cost);
+          addStat(message.member, "spent-garage", cost);
+          return showCars(await getGarage(message.member), index, msg, interaction);
         } else if (interaction.customId === "rename") {
           const modal = new ModalBuilder()
             .setCustomId("rename_modal")
@@ -319,11 +319,11 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
             embeds: [new CustomEmbed(message.member, "car name updated")],
           });
 
-          await setCarName(message.author.id, cars[index].id, name);
-          return showCars(await getGarage(message.author.id), index, msg);
+          await setCarName(message.member, cars[index].id, name);
+          return showCars(await getGarage(message.member), index, msg);
         } else if (interaction.customId.startsWith("upg-")) {
           const upgrade = interaction.customId.substring(4);
-          const inventory = await getInventory(message.author.id);
+          const inventory = await getInventory(message.member);
 
           if (!inventory.has(upgrade)) {
             await interaction.reply({
@@ -333,11 +333,11 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
             return showCars(cars, index, msg, interaction, false);
           }
 
-          addProgress(message.author.id, "mechanic", 1);
-          await addCarUpgrade(message.author.id, cars[index].id, getItems()[upgrade].upgrades);
-          await removeInventoryItem(message.author.id, upgrade, 1);
+          addProgress(message.member, "mechanic", 1);
+          await addCarUpgrade(message.member, cars[index].id, getItems()[upgrade].upgrades);
+          await removeInventoryItem(message.member, upgrade, 1);
 
-          return showCars(await getGarage(message.author.id), index, msg, interaction);
+          return showCars(await getGarage(message.member), index, msg, interaction);
         }
       }
     };
@@ -345,7 +345,7 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
     return pageManager();
   };
 
-  showCars(await getGarage(message.author.id));
+  showCars(await getGarage(message.member));
 }
 
 cmd.setRun(run);

--- a/src/commands/gay.ts
+++ b/src/commands/gay.ts
@@ -115,7 +115,7 @@ async function run(
 
   await send({ embeds: [embed] });
 
-  addProgress(message.author.id, "unsure", 1);
+  addProgress(message.member, "unsure", 1);
 }
 
 cmd.setRun(run);

--- a/src/commands/give.ts
+++ b/src/commands/give.ts
@@ -20,10 +20,10 @@ import { getRawLevel } from "../utils/functions/economy/levelling";
 import { createUser, isEcoBanned, userExists } from "../utils/functions/economy/utils";
 import { getPrefix } from "../utils/functions/guilds/utils";
 import { getMember } from "../utils/functions/member";
+import { pluralize } from "../utils/functions/string";
 import { getDmSettings } from "../utils/functions/users/notifications";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 import { transaction } from "../utils/logger";
-import { pluralize } from "../utils/functions/string";
 
 const cmd = new Command("give", "give other users items from your inventory", "money");
 

--- a/src/commands/guild.ts
+++ b/src/commands/guild.ts
@@ -294,7 +294,7 @@ async function run(
   }
 
   if (args[0].toLowerCase() == "create") {
-    const alts = await getAllGroupAccountIds(Constants.NYPSI_SERVER_ID, message.author.id);
+    const alts = await getAllGroupAccountIds(Constants.NYPSI_SERVER_ID, message.member);
 
     for (const accountId of alts) {
       if (await redis.exists(`${Constants.redis.cooldown.GUILD_CREATE}:${accountId}`)) {
@@ -353,7 +353,7 @@ async function run(
     await addCooldown(cmd.name, message.member, 3);
 
     await removeBalance(message.member, 500000);
-    addStat(message.author.id, "spent-guild", 500000);
+    addStat(message.member, "spent-guild", 500000);
 
     await createGuild(name, message.member);
 
@@ -414,11 +414,11 @@ async function run(
       return send({ embeds: [new ErrorEmbed("this user has already been invited to a guild")] });
     }
 
-    if ((await isEcoBanned(target.user.id)).banned) {
+    if ((await isEcoBanned(target)).banned) {
       return send({ embeds: [new ErrorEmbed("they're banned. lol. HA. HAHAHA.")] });
     }
 
-    if (!(await userExists(target.user.id))) {
+    if (!(await userExists(target))) {
       return send({ embeds: [new ErrorEmbed("invalid user")] });
     }
 
@@ -485,7 +485,7 @@ async function run(
         return send({ embeds: [new ErrorEmbed("guild invites/leaves are currently disabled")] });
       }
       invited.delete(target.user.id);
-      const targetGuild = await getGuildByUser(target.user.id);
+      const targetGuild = await getGuildByUser(target.user);
       const refreshedGuild = await getGuildByName(guild.guildName);
 
       if (targetGuild) {
@@ -833,7 +833,7 @@ async function run(
       }
 
       await removeBalance(message.member, amount);
-      addStat(message.author.id, "spent-guild", amount);
+      addStat(message.member, "spent-guild", amount);
 
       await addToGuildBank(guild.guildName, amount, message.member);
 

--- a/src/commands/hamster.ts
+++ b/src/commands/hamster.ts
@@ -70,7 +70,7 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
 
   send({ embeds: [embed] });
 
-  addProgress(message.author.id, "cute", 1);
+  addProgress(message.member, "cute", 1);
 }
 
 cmd.setRun(run);

--- a/src/commands/height.ts
+++ b/src/commands/height.ts
@@ -118,7 +118,7 @@ async function run(
 
   send({ embeds: [embed] });
 
-  addProgress(message.author.id, "unsure", 1);
+  addProgress(message.member, "unsure", 1);
 }
 
 cmd.setRun(run);

--- a/src/commands/highlow.ts
+++ b/src/commands/highlow.ts
@@ -350,7 +350,7 @@ async function prepareGame(
       .setDisabled(true),
   );
 
-  const desc = await renderGambleScreen(message.author.id, "playing", bet, `**0**x ($0)`);
+  const desc = await renderGambleScreen("playing", bet, `**0**x ($0)`);
 
   const embed = new CustomEmbed(message.member, desc)
     .setHeader("highlow", message.author.avatarURL())
@@ -444,7 +444,7 @@ async function playGame(
       percentChance(0.05) &&
       parseInt(await redis.get(`anticheat:interactivegame:count:${message.author.id}`)) > 100
     ) {
-      const res = await giveCaptcha(message.author.id);
+      const res = await giveCaptcha(message.member);
 
       if (res) {
         logger.info(
@@ -484,7 +484,7 @@ async function playGame(
       logger.info(
         `::cmd ${message.guild.id} ${message.channelId} ${message.author.username}: replaying highlow`,
       );
-      if (await isLockedOut(message.author.id)) return verifyUser(message);
+      if (await isLockedOut(message.member)) return verifyUser(message);
 
       addHourlyCommand(message.member);
 
@@ -539,7 +539,6 @@ async function playGame(
     newEmbed.setFooter({ text: `id: ${id}` });
     newEmbed.setColor(Constants.EMBED_FAIL_COLOR);
     const desc = await renderGambleScreen(
-      message.author.id,
       "lose",
       bet,
       `**${win}**x ($${Math.round(bet * win).toLocaleString()})`,
@@ -559,7 +558,6 @@ async function playGame(
     }
 
     const desc = await renderGambleScreen(
-      message.author.id,
       "win",
       bet,
       `**${win}**x ($${Math.round(bet * win).toLocaleString()})`,
@@ -587,7 +585,7 @@ async function playGame(
       }
     }
 
-    if (win >= 7) addProgress(message.author.id, "highlow_pro", 1);
+    if (win >= 7) addProgress(message.member, "highlow_pro", 1);
 
     const id = await createGame({
       userId: message.author.id,
@@ -629,7 +627,6 @@ async function playGame(
     newEmbed.setFooter({ text: `id: ${id}` });
     newEmbed.setColor(flavors.macchiato.colors.yellow.hex as ColorResolvable);
     const desc = await renderGambleScreen(
-      message.author.id,
       "draw",
       bet,
       `**${win}**x ($${Math.round(bet * win).toLocaleString()})`,
@@ -715,7 +712,6 @@ async function playGame(
       }
 
       const desc = await renderGambleScreen(
-        message.author.id,
         "playing",
         bet,
         `**${win}**x ($${Math.round(bet * win).toLocaleString()})`,
@@ -726,7 +722,6 @@ async function playGame(
       return playGame(message, m, args);
     } else if (newCard1 == oldCard) {
       const desc = await renderGambleScreen(
-        message.author.id,
         "playing",
         bet,
         `**${win}**x ($${Math.round(bet * win).toLocaleString()})`,
@@ -787,7 +782,6 @@ async function playGame(
       }
 
       const desc = await renderGambleScreen(
-        message.author.id,
         "playing",
         bet,
         `**${win}**x ($${Math.round(bet * win).toLocaleString()})`,
@@ -798,7 +792,6 @@ async function playGame(
       return playGame(message, m, args);
     } else if (newCard1 == oldCard) {
       const desc = await renderGambleScreen(
-        message.author.id,
         "playing",
         bet,
         `**${win}**x ($${Math.round(bet * win).toLocaleString()})`,

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -138,9 +138,9 @@ async function run(
     }
   }
 
-  const cases = (
-    await getCases(message.guild, member instanceof GuildMember ? member.user.id : member)
-  ).filter((i) => (filter ? i.type == filter : true));
+  const cases = (await getCases(message.guild, member)).filter((i) =>
+    filter ? i.type == filter : true,
+  );
 
   if (cases.length == 0) {
     return send({ embeds: [new ErrorEmbed("no history to display")] });

--- a/src/commands/horny.ts
+++ b/src/commands/horny.ts
@@ -129,7 +129,7 @@ async function run(
 
   await send({ embeds: [embed] });
 
-  addProgress(message.author.id, "unsure", 1);
+  addProgress(message.member, "unsure", 1);
 }
 
 cmd.setRun(run);

--- a/src/commands/hot.ts
+++ b/src/commands/hot.ts
@@ -141,7 +141,7 @@ async function run(
 
   await send({ embeds: [embed] });
 
-  addProgress(message.author.id, "unsure", 1);
+  addProgress(message.member, "unsure", 1);
 }
 
 cmd.setRun(run);

--- a/src/commands/hunt.ts
+++ b/src/commands/hunt.ts
@@ -11,6 +11,7 @@ import {
   MessageActionRowComponentBuilder,
   MessageFlags,
 } from "discord.js";
+import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
 import { addProgress } from "../utils/functions/economy/achievements";
@@ -28,7 +29,6 @@ import { createUser, getItems, userExists } from "../utils/functions/economy/uti
 import { addXp, calcEarnedHFMXp } from "../utils/functions/economy/xp";
 import { percentChance } from "../utils/functions/random";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
-import { NypsiClient } from "../models/Client";
 import { logger } from "../utils/logger";
 
 const cmd = new Command("hunt", "go to a field and hunt", "money");
@@ -158,13 +158,13 @@ async function doHunt(
 
   if ((await inventory.hasGem("purple_gem")).any) {
     if (percentChance(0.2)) {
-      gemBreak(message.member.user.id, 0.03, "purple_gem", message.client as NypsiClient);
+      gemBreak(message.member, 0.03, "purple_gem", message.client as NypsiClient);
       times++;
     }
   }
   if ((await inventory.hasGem("white_gem")).any) {
     if (percentChance(0.2)) {
-      gemBreak(message.member.user.id, 0.03, "white_gem", message.client as NypsiClient);
+      gemBreak(message.member, 0.03, "white_gem", message.client as NypsiClient);
       times++;
     }
   }
@@ -339,9 +339,9 @@ async function doHunt(
 
   send({ embeds: [embed], components: [row] });
 
-  addProgress(message.member.user.id, "hunter", total);
-  await addTaskProgress(message.member.user.id, "hunt_daily");
-  await addTaskProgress(message.member.user.id, "hunt_weekly");
+  addProgress(message.member, "hunter", total);
+  await addTaskProgress(message.member, "hunt_daily");
+  await addTaskProgress(message.member, "hunt_weekly");
 }
 
 cmd.setRun(run);

--- a/src/commands/iq.ts
+++ b/src/commands/iq.ts
@@ -86,8 +86,8 @@ async function run(
   } else {
     let chanceAmount = 25;
 
-    if (await isPremium(member.user.id)) {
-      if ((await getTier(member.user.id)) >= 3) {
+    if (await isPremium(member)) {
+      if ((await getTier(member)) >= 3) {
         chanceAmount = 10;
       }
     }
@@ -144,7 +144,7 @@ async function run(
 
   send({ embeds: [embed] });
 
-  addProgress(message.author.id, "unsure", 1);
+  addProgress(message.member, "unsure", 1);
 }
 
 cmd.setRun(run);

--- a/src/commands/item.ts
+++ b/src/commands/item.ts
@@ -22,8 +22,8 @@ import {
 import { countItemOnMarket } from "../utils/functions/economy/market";
 import { createUser, userExists } from "../utils/functions/economy/utils";
 import { getEmojiImage } from "../utils/functions/image";
-import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 import { pluralize } from "../utils/functions/string";
+import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 
 const cmd = new Command("item", "view information about an item", "money").setAliases(["i"]);
 

--- a/src/commands/karmashop.ts
+++ b/src/commands/karmashop.ts
@@ -367,7 +367,7 @@ async function run(
     await removeKarma(message.member, wanted.cost);
     await setKarmaShopItems(items);
     await redis.del(Constants.redis.nypsi.KARMA_SHOP_BUYING);
-    addProgress(message.author.id, "wizard", 1);
+    addProgress(message.member, "wizard", 1);
     const guild = await getGuildName(message.member);
 
     switch (wanted.type) {
@@ -391,7 +391,7 @@ async function run(
       await redis.set(Constants.redis.nypsi.GEM_GIVEN, "t", "EX", 86400);
       logger.info(`${message.author.id} received purple_gem randomly (karmashop)`);
       await addInventoryItem(message.member, "purple_gem", 1);
-      addProgress(message.author.id, "gem_hunter", 1);
+      addProgress(message.member, "gem_hunter", 1);
       addNotificationToQueue({
         memberId: message.author.id,
         payload: {

--- a/src/commands/lottery.ts
+++ b/src/commands/lottery.ts
@@ -83,7 +83,7 @@ async function run(
     const embed = new CustomEmbed(message.member);
 
     const pool = await getApproximatePrizePool();
-    const autoBuy = await getDailyLottoTickets(message.author.id);
+    const autoBuy = await getDailyLottoTickets(message.member);
 
     embed.setHeader("lottery", message.author.avatarURL());
     embed.setDescription(
@@ -126,7 +126,7 @@ async function run(
       return send({ embeds: [new ErrorEmbed("invalid number")] });
     }
 
-    await setDailyLotteryTickets(message.author.id, amount);
+    await setDailyLotteryTickets(message.member, amount);
 
     return send({
       embeds: [

--- a/src/commands/love.ts
+++ b/src/commands/love.ts
@@ -209,7 +209,7 @@ async function run(
 
   send({ embeds: [embed] });
 
-  addProgress(message.author.id, "unsure", 1);
+  addProgress(message.member, "unsure", 1);
 }
 
 cmd.setRun(run);

--- a/src/commands/marry.ts
+++ b/src/commands/marry.ts
@@ -14,14 +14,14 @@ import {
 } from "discord.js";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
-import { createUser, getItems, userExists } from "../utils/functions/economy/utils";
-import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
-import { addMarriage, isMarried } from "../utils/functions/users/marriage";
 import {
   addInventoryItem,
   getInventory,
   removeInventoryItem,
 } from "../utils/functions/economy/inventory";
+import { createUser, getItems, userExists } from "../utils/functions/economy/utils";
+import { addMarriage, isMarried } from "../utils/functions/users/marriage";
+import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 
 const cmd = new Command("marry", "marry your ekitten", "fun");
 
@@ -137,7 +137,7 @@ async function run(
     });
   }
 
-  if (!(await userExists(target.user.id))) {
+  if (!(await userExists(target))) {
     return send({ embeds: [new ErrorEmbed("invalid user")], flags: MessageFlags.Ephemeral });
   }
 

--- a/src/commands/mine.ts
+++ b/src/commands/mine.ts
@@ -11,6 +11,7 @@ import {
   MessageActionRowComponentBuilder,
   MessageFlags,
 } from "discord.js";
+import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
 import { addProgress } from "../utils/functions/economy/achievements";
@@ -28,7 +29,6 @@ import { createUser, getItems, userExists } from "../utils/functions/economy/uti
 import { addXp, calcEarnedHFMXp } from "../utils/functions/economy/xp";
 import { percentChance } from "../utils/functions/random";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
-import { NypsiClient } from "../models/Client";
 
 const veins = new Map<string, number[]>();
 
@@ -188,13 +188,13 @@ async function doMine(
 
   if ((await inventory.hasGem("purple_gem")).any) {
     if (percentChance(0.2)) {
-      gemBreak(message.member.user.id, 0.03, "purple_gem", message.client as NypsiClient);
+      gemBreak(message.member, 0.03, "purple_gem", message.client as NypsiClient);
       times++;
     }
   }
   if ((await inventory.hasGem("white_gem")).any) {
     if (percentChance(0.2)) {
-      gemBreak(message.member.user.id, 0.03, "white_gem", message.client as NypsiClient);
+      gemBreak(message.member, 0.03, "white_gem", message.client as NypsiClient);
       times++;
     }
   }
@@ -385,9 +385,9 @@ async function doMine(
 
   send({ embeds: [embed], components: [row] });
 
-  addProgress(message.member.user.id, "miner", total);
-  await addTaskProgress(message.member.user.id, "mine_daily");
-  await addTaskProgress(message.member.user.id, "mine_weekly");
+  addProgress(message.member, "miner", total);
+  await addTaskProgress(message.member, "mine_daily");
+  await addTaskProgress(message.member, "mine_weekly");
 }
 
 cmd.setRun(run);

--- a/src/commands/mines.ts
+++ b/src/commands/mines.ts
@@ -424,7 +424,7 @@ async function prepareGame(
     }
   }, ms("5 minutes"));
 
-  const desc = await renderGambleScreen(message.author.id, "playing", bet, "**0**x ($0)");
+  const desc = await renderGambleScreen("playing", bet, "**0**x ($0)");
   const embed = new CustomEmbed(message.member, desc).setHeader(
     "mines",
     message.author.avatarURL(),
@@ -558,7 +558,7 @@ async function playGame(
       percentChance(0.05) &&
       parseInt(await redis.get(`anticheat:interactivegame:count:${message.author.id}`)) > 100
     ) {
-      const res = await giveCaptcha(message.author.id);
+      const res = await giveCaptcha(message.member);
 
       if (res) {
         logger.info(
@@ -623,7 +623,7 @@ async function playGame(
       logger.info(
         `::cmd ${message.guild.id} ${message.channelId} ${message.author.username}: replaying mines`,
       );
-      if (await isLockedOut(message.author.id)) {
+      if (await isLockedOut(message.member)) {
         await verifyUser(message);
         return replay(embed, interaction, false);
       }
@@ -679,7 +679,6 @@ async function playGame(
     embed.setFooter({ text: `id: ${id}` });
     embed.setColor(Constants.EMBED_FAIL_COLOR);
     const desc = await renderGambleScreen(
-      message.author.id,
       "lose",
       bet,
       `**${win.toFixed(2)}**x ($${Math.round(bet * win).toLocaleString()})`,
@@ -698,7 +697,6 @@ async function playGame(
     }
 
     const desc = await renderGambleScreen(
-      message.author.id,
       "win",
       bet,
       `**${win.toFixed(2)}**x ($${Math.round(bet * win).toLocaleString()})`,
@@ -760,7 +758,6 @@ async function playGame(
     embed.setFooter({ text: `id: ${id}` });
     embed.setColor(flavors.macchiato.colors.yellow.hex as ColorResolvable);
     const desc = await renderGambleScreen(
-      message.author.id,
       "draw",
       bet,
       `**${win.toFixed(2)}**x ($${Math.round(bet * win).toLocaleString()})`,
@@ -906,7 +903,6 @@ async function playGame(
       });
 
       const desc = await renderGambleScreen(
-        message.author.id,
         "playing",
         bet,
         `**${win.toFixed(2)}**x ($${Math.round(bet * win).toLocaleString()})`,

--- a/src/commands/multi.ts
+++ b/src/commands/multi.ts
@@ -1,10 +1,10 @@
 import { CommandInteraction } from "discord.js";
+import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed } from "../models/EmbedBuilders.js";
 import { getGambleMulti, getSellMulti } from "../utils/functions/economy/balance";
 import { createUser, userExists } from "../utils/functions/economy/utils.js";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
-import { NypsiClient } from "../models/Client";
 
 const cmd = new Command("multi", "check your multipliers", "money").setAliases([
   "multis",

--- a/src/commands/mute.ts
+++ b/src/commands/mute.ts
@@ -217,7 +217,7 @@ async function run(
     return;
   }
 
-  const ids = await getAllGroupAccountIds(message.guild, target.user.id);
+  const ids = await getAllGroupAccountIds(message.guild, target);
 
   if (ids.includes(message.member.user.id)) {
     await message.channel.send({ embeds: [new ErrorEmbed("you cannot mute one of your alts")] });

--- a/src/commands/networth.ts
+++ b/src/commands/networth.ts
@@ -6,6 +6,7 @@ import {
   MessageActionRowComponentBuilder,
 } from "discord.js";
 import { inPlaceSort } from "fast-sort";
+import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
 import { calcNetWorth } from "../utils/functions/economy/balance";
@@ -17,7 +18,6 @@ import { isUserBlacklisted } from "../utils/functions/users/blacklist";
 import { hasProfile } from "../utils/functions/users/utils";
 import { addView } from "../utils/functions/users/views";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
-import { NypsiClient } from "../models/Client";
 
 const cmd = new Command("networth", "view breakdown of your networth", "money").setAliases([
   "net",
@@ -54,7 +54,7 @@ async function run(
 
   if (!(await userExists(target))) await createUser(target);
 
-  if ((await isUserBlacklisted(target.user.id)).blacklisted)
+  if ((await isUserBlacklisted(target)).blacklisted)
     return message.channel.send({
       embeds: [
         new ErrorEmbed(
@@ -63,7 +63,7 @@ async function run(
       ],
     });
 
-  if ((await isEcoBanned(target.user.id)).banned)
+  if ((await isEcoBanned(target)).banned)
     return message.channel.send({
       embeds: [new ErrorEmbed(`${target.toString()} is banned AHAHAHAHA`)],
     });

--- a/src/commands/offer.ts
+++ b/src/commands/offer.ts
@@ -140,7 +140,7 @@ async function run(
   const items = getItems();
 
   const manageOffers = async (msg?: Message) => {
-    const offers = await getOwnedOffers(message.author.id);
+    const offers = await getOwnedOffers(message.member);
 
     const embed = new CustomEmbed(message.member).setHeader(
       "your offers",
@@ -304,7 +304,7 @@ async function run(
   if (args.length == 0 || args[0].toLowerCase() == "manage") {
     return manageOffers();
   } else if (args[0].toLowerCase() == "block") {
-    let current = await getBlockedList(message.author.id);
+    let current = await getBlockedList(message.member);
     const max = 100;
 
     const items = getItems();
@@ -372,7 +372,7 @@ async function run(
 
       current.splice(current.indexOf(value), 1);
 
-      current = await setBlockedList(message.author.id, current);
+      current = await setBlockedList(message.member, current);
     } else {
       if (current.length >= max) {
         return send({ embeds: [new ErrorEmbed("you have reached the limit of your blocklist")] });
@@ -381,7 +381,7 @@ async function run(
       desc = `✅ added \`${value}\``;
 
       current.push(value);
-      current = await setBlockedList(message.author.id, current);
+      current = await setBlockedList(message.member, current);
     }
 
     const embed = new CustomEmbed(message.member, desc).setHeader(
@@ -413,7 +413,7 @@ async function run(
       max *= await getTier(message.member);
     }
 
-    const currentOffers = await getOwnedOffers(message.author.id);
+    const currentOffers = await getOwnedOffers(message.member);
 
     if (currentOffers.length + 1 > max)
       return send({
@@ -430,10 +430,10 @@ async function run(
       return send({ embeds: [new ErrorEmbed("lol xd cant offer yourself something")] });
     }
 
-    if ((await isEcoBanned(target.user.id)).banned)
+    if ((await isEcoBanned(target)).banned)
       return send({ embeds: [new ErrorEmbed("theyre banned lol xd be mean to them for me ty")] });
 
-    if ((await getPreferences(target)).offers <= (await getTargetedOffers(target.user.id)).length) {
+    if ((await getPreferences(target)).offers <= (await getTargetedOffers(target)).length) {
       if ((await getPreferences(target)).offers === 0)
         return send({
           embeds: [new ErrorEmbed(`**${target.user.username}** has disabled offers`)],
@@ -456,7 +456,7 @@ async function run(
     if (selected.account_locked)
       return send({ embeds: [new ErrorEmbed("this item cant be traded")] });
 
-    const blocked = await getBlockedList(target.user.id);
+    const blocked = await getBlockedList(target);
 
     if (blocked.includes(selected.id))
       return send({

--- a/src/commands/pay.ts
+++ b/src/commands/pay.ts
@@ -105,7 +105,7 @@ async function run(
     return send({ embeds: [new ErrorEmbed("invalid user")] });
   }
 
-  if ((await isEcoBanned(target.user.id)).banned) {
+  if ((await isEcoBanned(target)).banned) {
     return send({ embeds: [new ErrorEmbed("they are banned xd")] });
   }
 
@@ -152,7 +152,7 @@ async function run(
     await addCooldown(cmd.name, message.member, 10);
     await removeBalance(message.member, amount);
     await addToNypsiBank(amount);
-    addStat(message.author.id, "spent-bank", amount);
+    addStat(message.member, "spent-bank", amount);
 
     return send({
       embeds: [
@@ -167,7 +167,7 @@ async function run(
   await addCooldown(cmd.name, message.member, 10);
 
   await removeBalance(message.member, amount);
-  addStat(message.author.id, "spent-pay", amount);
+  addStat(message.member, "spent-pay", amount);
 
   let taxedAmount = 0;
 
@@ -175,10 +175,10 @@ async function run(
     taxedAmount = Math.floor(amount * tax);
     await addToNypsiBank(taxedAmount * 0.5);
     await addBalance(target, amount - taxedAmount);
-    addStat(target.user.id, "earned-pay", amount - taxedAmount);
+    addStat(target, "earned-pay", amount - taxedAmount);
   } else {
     await addBalance(target, amount);
-    addStat(target.user.id, "earned-pay", amount);
+    addStat(target, "earned-pay", amount);
   }
 
   if ((await getDmSettings(target)).payment) {

--- a/src/commands/pings.ts
+++ b/src/commands/pings.ts
@@ -96,11 +96,11 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
   const showMentions = async (msg?: Message) => {
     let limit = 9;
 
-    if (await isPremium(message.author.id)) {
+    if (await isPremium(message.member)) {
       limit = 207;
     }
 
-    const preferences = await getPreferences(message.author.id);
+    const preferences = await getPreferences(message.member);
 
     const mentions = await fetchUserMentions(
       message.member,
@@ -214,7 +214,7 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
           async (manager: PageManager<string>, interaction: ButtonInteraction) => {
             await interaction.deferUpdate();
             preferences.mentionsGlobal = !preferences.mentionsGlobal;
-            await updatePreferences(message.author.id, preferences);
+            await updatePreferences(message.member, preferences);
 
             return showMentions(manager.message);
           },

--- a/src/commands/pp.ts
+++ b/src/commands/pp.ts
@@ -15,8 +15,8 @@ import { addTaskProgress } from "../utils/functions/economy/tasks";
 import { getItems } from "../utils/functions/economy/utils";
 import { getMember } from "../utils/functions/member";
 import { getTier, isPremium } from "../utils/functions/premium/premium";
-import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 import { pluralize } from "../utils/functions/string";
+import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 
 const cache = new Map<string, number>();
 
@@ -96,8 +96,8 @@ async function run(
 
     let chance = 45;
 
-    if (await isPremium(member.user.id)) {
-      if ((await getTier(member.user.id)) >= 3) {
+    if (await isPremium(member)) {
+      if ((await getTier(member)) >= 3) {
         chance = 10;
       }
     }
@@ -136,13 +136,12 @@ async function run(
 
   send({ embeds: [embed] });
 
-  addProgress(message.author.id, "unsure", 1);
+  addProgress(message.member, "unsure", 1);
 
-  if (size < 5 && member.user.id === message.author.id)
-    addTaskProgress(message.author.id, "pp_small");
+  if (size < 5 && member.user.id === message.author.id) addTaskProgress(message.member, "pp_small");
   else if (size > 6 && member.user.id === message.author.id)
-    addTaskProgress(message.author.id, "pp_big");
-  else if (member.user.id === message.author.id) addTaskProgress(message.author.id, "pp");
+    addTaskProgress(message.member, "pp_big");
+  else if (member.user.id === message.author.id) addTaskProgress(message.member, "pp");
 }
 
 cmd.setRun(run);

--- a/src/commands/rabbit.ts
+++ b/src/commands/rabbit.ts
@@ -76,7 +76,7 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
 
   send({ embeds: [embed] });
 
-  addProgress(message.author.id, "cute", 1);
+  addProgress(message.member, "cute", 1);
 }
 
 cmd.setRun(run);

--- a/src/commands/race.ts
+++ b/src/commands/race.ts
@@ -199,7 +199,7 @@ class Race {
 
   private async collectorFunction(interaction: ButtonInteraction): Promise<any> {
     if (interaction.customId === "join") {
-      if (!(await userExists(interaction.user.id)))
+      if (!(await userExists(interaction.user)))
         return interaction.reply({
           flags: MessageFlags.Ephemeral,
           embeds: [new ErrorEmbed("you cannot afford the entry fee for this race")],
@@ -209,14 +209,14 @@ class Race {
         return interaction.deferUpdate();
 
       const [garage, inventory, balance] = await Promise.all([
-        getGarage(interaction.user.id),
-        getInventory(interaction.user.id).then((i) =>
+        getGarage(interaction.user),
+        getInventory(interaction.user).then((i) =>
           i.entries.filter((i) => getItems()[i.item].role === "car"),
         ),
-        getBalance(interaction.user.id),
+        getBalance(interaction.user),
       ]);
 
-      const maxBet = (await calcMaxBet(interaction.user.id)) * 10;
+      const maxBet = (await calcMaxBet(interaction.user)) * 10;
 
       if (maxBet < this.bet)
         return interaction.reply({
@@ -286,7 +286,7 @@ class Race {
         .reply({
           flags: MessageFlags.Ephemeral,
           embeds: [
-            new CustomEmbed(interaction.user.id, "choose a car").setHeader(
+            new CustomEmbed(interaction.user, "choose a car").setHeader(
               this.embed.data.author.name,
               this.embed.data.author.icon_url,
             ),
@@ -305,7 +305,7 @@ class Race {
 
       if (!carInteraction) return;
 
-      if ((await getBalance(interaction.user.id)) < this.bet)
+      if ((await getBalance(interaction.user)) < this.bet)
         return carInteraction.reply({
           flags: MessageFlags.Ephemeral,
           embeds: [new ErrorEmbed("you cannot afford the entry fee for this race")],
@@ -322,7 +322,7 @@ class Race {
           embeds: [new ErrorEmbed("this car is faster than the speed limit for this race")],
         });
 
-      await removeBalance(interaction.user.id, this.bet);
+      await removeBalance(interaction.user, this.bet);
 
       this.members.push({
         car: cars.find((i) => i.car.id === chosen),
@@ -405,7 +405,7 @@ class Race {
     if (this.members.length < 2) {
       if (this.bet > 0) {
         for (const member of this.members) {
-          await addBalance(member.user.id, this.bet);
+          await addBalance(member.user, this.bet);
         }
       }
 
@@ -426,7 +426,7 @@ class Race {
 
         if (this.bet > 0) {
           for (const member of this.members) {
-            await addBalance(member.user.id, this.bet);
+            await addBalance(member.user, this.bet);
           }
         }
 
@@ -496,7 +496,7 @@ class Race {
             });
           }
 
-          addStat(member.user.id, member.car.car.id.toString(), 1);
+          addStat(member.user, member.car.car.id.toString(), 1);
 
           await createGame({
             userId: member.user.id,

--- a/src/commands/reload.ts
+++ b/src/commands/reload.ts
@@ -1,9 +1,9 @@
 import { CommandInteraction, Message } from "discord.js";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
+import { getAdminLevel } from "../utils/functions/users/admin";
 import { loadCommands, reloadCommand } from "../utils/handlers/commandhandler";
 import { reloadInteractions } from "../utils/handlers/interactions";
 import { logger } from "../utils/logger";
-import { getAdminLevel } from "../utils/functions/users/admin";
 
 const cmd = new Command("reload", "reload commands", "none").setPermissions(["bot owner"]);
 

--- a/src/commands/reloaditems.ts
+++ b/src/commands/reloaditems.ts
@@ -4,8 +4,8 @@ import prisma from "../init/database";
 import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { getTasksData, loadItems } from "../utils/functions/economy/utils";
-import { logger } from "../utils/logger";
 import { getAdminLevel } from "../utils/functions/users/admin";
+import { logger } from "../utils/logger";
 
 const cmd = new Command("reloaditems", "reload items", "none").setPermissions(["bot owner"]);
 

--- a/src/commands/reloadslash.ts
+++ b/src/commands/reloadslash.ts
@@ -1,7 +1,7 @@
 import { CommandInteraction, Message } from "discord.js";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
-import { uploadSlashCommands, uploadSlashCommandsToGuild } from "../utils/handlers/commandhandler";
 import { getAdminLevel } from "../utils/functions/users/admin";
+import { uploadSlashCommands, uploadSlashCommandsToGuild } from "../utils/handlers/commandhandler";
 
 const cmd = new Command("reloadslash", "reload data for slash commands", "none").setPermissions([
   "bot owner",

--- a/src/commands/requestdm.ts
+++ b/src/commands/requestdm.ts
@@ -14,7 +14,7 @@ async function run(
   message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction),
   args: string[],
 ) {
-  if ((await getAdminLevel(message.author.id)) < 2) return;
+  if ((await getAdminLevel(message.member)) < 2) return;
 
   if (args.length < 2) {
     return message.channel.send({ embeds: [new ErrorEmbed("$requestdm <id> <content>")] });

--- a/src/commands/rob.ts
+++ b/src/commands/rob.ts
@@ -8,6 +8,7 @@ import {
   MessageFlags,
 } from "discord.js";
 import redis from "../init/redis";
+import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
 import Constants from "../utils/Constants";
@@ -31,7 +32,6 @@ import { getMember } from "../utils/functions/member";
 import { isUserBlacklisted } from "../utils/functions/users/blacklist";
 import { getDmSettings } from "../utils/functions/users/notifications";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
-import { NypsiClient } from "../models/Client";
 import ms = require("ms");
 
 const playerCooldown = new Set<string>();
@@ -150,7 +150,7 @@ async function run(
     return send({ embeds: [new ErrorEmbed("invalid user")] });
   }
 
-  if ((await isEcoBanned(target.user.id)).banned) {
+  if ((await isEcoBanned(target)).banned) {
     return send({ embeds: [new ErrorEmbed("they are banned xd xd xd xd xd xd lol")] });
   }
 
@@ -313,8 +313,8 @@ async function run(
         1_000_000,
         1,
       );
-      addProgress(message.author.id, "robber", 1);
-      addTaskProgress(message.author.id, "thief");
+      addProgress(message.member, "robber", 1);
+      addTaskProgress(message.member, "thief");
 
       if (earnedXp > 0) {
         await addXp(message.member, earnedXp);

--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -25,8 +25,8 @@ import {
 import { getMember, getRole } from "../utils/functions/member";
 import PageManager from "../utils/functions/page";
 import sleep from "../utils/functions/sleep";
-import { logger } from "../utils/logger";
 import { pluralize } from "../utils/functions/string";
+import { logger } from "../utils/logger";
 
 const cmd = new Command("role", "role utilities", "utility");
 
@@ -239,7 +239,7 @@ async function run(
     let role: Role;
 
     if (!(message instanceof Message) && message.isChatInputCommand()) {
-      role = await message.guild.roles.cache.get(message.options.getRole("role").id);
+      role = message.guild.roles.cache.get(message.options.getRole("role").id);
     } else if (message.mentions?.roles?.first()) {
       role = message.mentions.roles.first();
     } else {

--- a/src/commands/roulette.ts
+++ b/src/commands/roulette.ts
@@ -9,6 +9,7 @@ import {
   MessageFlags,
 } from "discord.js";
 import redis from "../init/redis";
+import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
 import Constants from "../utils/Constants.js";
@@ -29,7 +30,6 @@ import { getPrefix } from "../utils/functions/guilds/utils";
 import { shuffle } from "../utils/functions/random";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler.js";
 import { gamble } from "../utils/logger.js";
-import { NypsiClient } from "../models/Client";
 
 const values = [
   "b",
@@ -301,7 +301,7 @@ async function run(
       await addBalance(message.member, winnings);
     }
 
-    if (roll == "🟢") addProgress(message.author.id, "roulette_pro", 1);
+    if (roll == "🟢") addProgress(message.member, "roulette_pro", 1);
   } else {
     await removeBalance(message.member, bet);
   }

--- a/src/commands/rps.ts
+++ b/src/commands/rps.ts
@@ -8,6 +8,7 @@ import {
   MessageFlags,
 } from "discord.js";
 import redis from "../init/redis";
+import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
 import Constants from "../utils/Constants.js";
@@ -27,7 +28,6 @@ import { getPrefix } from "../utils/functions/guilds/utils";
 import { shuffle } from "../utils/functions/random";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler.js";
 import { gamble } from "../utils/logger.js";
-import { NypsiClient } from "../models/Client";
 
 const cmd = new Command("rps", "play rock paper scissors", "money").setAliases([
   "rockpaperscissors",

--- a/src/commands/sell.ts
+++ b/src/commands/sell.ts
@@ -12,6 +12,7 @@ import {
   MessageFlags,
 } from "discord.js";
 import { inPlaceSort } from "fast-sort";
+import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
 import Constants from "../utils/Constants";
@@ -30,7 +31,6 @@ import PageManager from "../utils/functions/page";
 import { getTier, isPremium } from "../utils/functions/premium/premium";
 import { addToNypsiBank, getTax } from "../utils/functions/tax";
 import { addCooldown, addExpiry, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
-import { NypsiClient } from "../models/Client";
 import pAll = require("p-all");
 
 const cmd = new Command("sell", "sell items", "money");
@@ -204,7 +204,7 @@ async function run(
         await addBalance(message.member, total);
       });
 
-      addStat(message.author.id, "earned-sold", total);
+      addStat(message.member, "earned-sold", total);
 
       await pAll(functions, { concurrency: 5 });
 
@@ -433,7 +433,7 @@ async function run(
 
     await addBalance(message.member, sellWorth);
 
-    addStat(message.author.id, "earned-sold", sellWorth);
+    addStat(message.member, "earned-sold", sellWorth);
 
     const embed = new CustomEmbed(message.member);
 

--- a/src/commands/sellinv.ts
+++ b/src/commands/sellinv.ts
@@ -12,6 +12,7 @@ import {
   MessageFlags,
 } from "discord.js";
 import { inPlaceSort } from "fast-sort";
+import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
 import Constants from "../utils/Constants";
@@ -23,7 +24,6 @@ import PageManager from "../utils/functions/page";
 import { getTier, isPremium } from "../utils/functions/premium/premium";
 import { addToNypsiBank, getTax } from "../utils/functions/tax";
 import { addCooldown, addExpiry, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
-import { NypsiClient } from "../models/Client";
 import pAll = require("p-all");
 
 const cmd = new Command("sellinv", "sell your entire inventory", "money");
@@ -154,7 +154,7 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
       await addBalance(message.member, total);
     });
 
-    addStat(message.author.id, "earned-sold", total);
+    addStat(message.member, "earned-sold", total);
 
     await pAll(functions, { concurrency: 5 });
 

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -804,7 +804,7 @@ async function run(
   };
 
   const doEmail = async () => {
-    const email = await getEmail(message.author.id);
+    const email = await getEmail(message.member);
 
     const embed = new CustomEmbed(message.member);
     const row = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
@@ -891,7 +891,7 @@ async function run(
 
       await modalSubmit.deferUpdate();
 
-      await setEmail(message.author.id, value.toLowerCase()).catch(() => {
+      await setEmail(message.member, value.toLowerCase()).catch(() => {
         fail = true;
       });
 
@@ -902,7 +902,7 @@ async function run(
         });
       }
 
-      checkPurchases(message.author.id);
+      checkPurchases(message.member);
 
       return res.message.edit({
         embeds: [new CustomEmbed(message.member, "✅ your email has been set")],

--- a/src/commands/sex.ts
+++ b/src/commands/sex.ts
@@ -222,13 +222,13 @@ async function run(
 
       await Promise.all([
         send({ embeds: [embed] }),
-        addProgress(message.author.id, "whore", 1),
+        addProgress(message.member, "whore", 1),
         addProgress(milf.userId, "whore", 1),
-        addTaskProgress(message.author.id, "horny"),
+        addTaskProgress(message.member, "horny"),
         addTaskProgress(milf.userId, "horny"),
       ]);
 
-      const authorTag = await getActiveTag(message.author.id);
+      const authorTag = await getActiveTag(message.member);
 
       const embed2 = new CustomEmbed(
         undefined,

--- a/src/commands/slots.ts
+++ b/src/commands/slots.ts
@@ -10,6 +10,7 @@ import {
   MessageFlags,
 } from "discord.js";
 import redis from "../init/redis";
+import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
 import Constants from "../utils/Constants.js";
@@ -31,7 +32,6 @@ import { getPrefix } from "../utils/functions/guilds/utils";
 import { shuffle } from "../utils/functions/random";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler.js";
 import { gamble } from "../utils/logger.js";
-import { NypsiClient } from "../models/Client";
 
 const staticEmojis = new Map<string, string>();
 const animatedEmojis = new Map<string, string>();
@@ -368,7 +368,7 @@ async function run(
     win = true;
     winnings = Math.round(multiplier * bet);
 
-    if (one.split("-")[0] == "cherry") addProgress(message.author.id, "slots_pro", 1);
+    if (one.split("-")[0] == "cherry") addProgress(message.member, "slots_pro", 1);
   } else if (one.split("-")[0] == two.split("-")[0]) {
     win = true;
     winnings = Math.round(bet * 1.2);

--- a/src/commands/slut.ts
+++ b/src/commands/slut.ts
@@ -127,7 +127,7 @@ async function run(
     `${member.user.toString()}\n**${slutAmount}**% slut ${slutEmoji}\n${slutText}`,
   ).setTitle("slut calculator");
 
-  addProgress(message.author.id, "unsure", 1);
+  addProgress(message.member, "unsure", 1);
 
   return await send({ embeds: [embed] });
 }

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -786,7 +786,7 @@ async function run(
   };
 
   const lbStats = async () => {
-    const positions = await getLeaderboardPositions(message.author.id);
+    const positions = await getLeaderboardPositions(message.member);
 
     const embed = new CustomEmbed(message.member).setHeader(
       "leaderboard positions",

--- a/src/commands/streakpause.ts
+++ b/src/commands/streakpause.ts
@@ -10,7 +10,7 @@ async function run(
   message: NypsiMessage | (NypsiCommandInteraction & CommandInteraction),
   args: string[],
 ) {
-  if ((await getAdminLevel(message.author.id)) < 5) return;
+  if ((await getAdminLevel(message.member)) < 5) return;
 
   if (args.length === 0) {
     await redis.set("nypsi:streakpause", 69, "EX", ms("1 day") / 1000);

--- a/src/commands/tags.ts
+++ b/src/commands/tags.ts
@@ -55,7 +55,7 @@ cmd.setRun((message, args) => {
   };
 
   const listTags = async () => {
-    const tags = await getTags(message.author.id);
+    const tags = await getTags(message.member);
     const tagData = getTagsData();
 
     if (tags.length === 0) {
@@ -110,7 +110,7 @@ cmd.setRun((message, args) => {
   };
 
   const selectTag = async (search: string) => {
-    const tags = await getTags(message.author.id);
+    const tags = await getTags(message.member);
     const tagData = getTagsData();
 
     let selected: Tag;
@@ -132,14 +132,14 @@ cmd.setRun((message, args) => {
     }
 
     if (search === "none") {
-      await setActiveTag(message.author.id, "none");
+      await setActiveTag(message.member, "none");
 
       return send({
         embeds: [new CustomEmbed(message.member, `disabled any active tag`)],
       });
     }
 
-    await setActiveTag(message.author.id, selected.id);
+    await setActiveTag(message.member, selected.id);
 
     return send({
       embeds: [
@@ -153,7 +153,7 @@ cmd.setRun((message, args) => {
 
   const listAllTags = async () => {
     const tagData = getTagsData();
-    const userTags = await getTags(message.author.id);
+    const userTags = await getTags(message.member);
 
     const tagList: { title: string; value: string; owned: boolean }[] = [];
 

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -66,8 +66,8 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
 
   await addCooldown(cmd.name, message.member, 5);
 
-  const tasks = await getTasks(message.author.id);
-  const streaks = await getTaskStreaks(message.author.id);
+  const tasks = await getTasks(message.member);
+  const streaks = await getTaskStreaks(message.member);
 
   const row = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
     new ButtonBuilder()

--- a/src/commands/toggletracking.ts
+++ b/src/commands/toggletracking.ts
@@ -21,8 +21,8 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
 
   await addCooldown(cmd.name, message.member, 90);
 
-  if (await isTracking(message.author.id)) {
-    await disableTracking(message.author.id);
+  if (await isTracking(message.member)) {
+    await disableTracking(message.member);
     return message.channel.send({
       embeds: [
         new CustomEmbed(
@@ -34,7 +34,7 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
       ],
     });
   } else {
-    await enableTracking(message.author.id);
+    await enableTracking(message.member);
     return message.channel.send({
       embeds: [new CustomEmbed(message.member, "✅ username and avatar tracking has been enabled")],
     });

--- a/src/commands/top.ts
+++ b/src/commands/top.ts
@@ -49,12 +49,12 @@ import {
 import { getItems } from "../utils/functions/economy/utils.js";
 import { getPrefix } from "../utils/functions/guilds/utils";
 import PageManager from "../utils/functions/page";
-import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler.js";
 import {
   commandAliasExists,
   commandExists,
   getCommandFromAlias,
 } from "../utils/handlers/commandhandler";
+import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler.js";
 
 const cmd = new Command("top", "view top etc. in the server", "money").setAliases([
   "baltop",
@@ -326,11 +326,11 @@ async function run(
   };
 
   if (args.length == 0) {
-    const data = await topBalance(message.guild, message.author.id);
+    const data = await topBalance(message.guild, message.member);
 
     return show(data.pages, data.pos, `top balance for ${message.guild.name}`);
   } else if (args[0].toLowerCase() == "balance") {
-    const data = await topBalance(message.guild, message.author.id);
+    const data = await topBalance(message.guild, message.member);
 
     return show(data.pages, data.pos, `top balance for ${message.guild.name}`);
   } else if (args[0].toLowerCase() == "prestige" || args[0].toLowerCase() === "level") {
@@ -341,9 +341,9 @@ async function run(
     let data: { pages: Map<number, string[]>; pos: number };
 
     if (global) {
-      data = await topPrestigeGlobal(message.author.id);
+      data = await topPrestigeGlobal(message.member);
     } else {
-      data = await topPrestige(message.guild, message.author.id);
+      data = await topPrestige(message.guild, message.member);
     }
 
     return show(
@@ -394,9 +394,9 @@ async function run(
     let data: { pages: Map<number, string[]>; pos: number };
 
     if (global) {
-      data = await topItemGlobal(item.id, message.author.id);
+      data = await topItemGlobal(item.id, message.member);
     } else {
-      data = await topItem(message.guild, item.id, message.author.id);
+      data = await topItem(message.guild, item.id, message.member);
     }
 
     return show(
@@ -406,7 +406,7 @@ async function run(
       global ? `https://nypsi.xyz/leaderboard/${item.id}?ref=bot-lb` : null,
     );
   } else if (args[0].toLowerCase() == "completion") {
-    const data = await topCompletion(message.guild, message.author.id);
+    const data = await topCompletion(message.guild, message.member);
 
     return show(data.pages, data.pos, `top completion in ${message.guild.name}`);
   } else if (args[0].toLowerCase() == "net" || args[0].toLowerCase() == "networth") {
@@ -417,9 +417,9 @@ async function run(
     let data: { pages: Map<number, string[]>; pos: number };
 
     if (global) {
-      data = await topNetWorthGlobal(message.author.id);
+      data = await topNetWorthGlobal(message.member);
     } else {
-      data = await topNetWorth(message.guild, message.author.id);
+      data = await topNetWorth(message.guild, message.member);
     }
 
     return show(
@@ -447,9 +447,9 @@ async function run(
     let data: { pages: Map<number, string[]>; pos: number };
 
     if (global) {
-      data = await topDailyStreakGlobal(message.author.id);
+      data = await topDailyStreakGlobal(message.member);
     } else {
-      data = await topDailyStreak(message.guild, message.author.id);
+      data = await topDailyStreak(message.guild, message.member);
     }
 
     return show(
@@ -466,9 +466,9 @@ async function run(
     let data: { pages: Map<number, string[]>; pos: number };
 
     if (global) {
-      data = await topLottoWinsGlobal(message.author.id);
+      data = await topLottoWinsGlobal(message.member);
     } else {
-      data = await topLottoWins(message.guild, message.author.id);
+      data = await topLottoWins(message.guild, message.member);
     }
 
     return show(
@@ -485,9 +485,9 @@ async function run(
     let data: { pages: Map<number, string[]>; pos: number };
 
     if (global) {
-      data = await topWordleTimeGlobal(message.author.id);
+      data = await topWordleTimeGlobal(message.member);
     } else {
-      data = await topWordleTime(message.guild, message.author.id);
+      data = await topWordleTime(message.guild, message.member);
     }
 
     return show(
@@ -504,9 +504,9 @@ async function run(
     let data: { pages: Map<number, string[]>; pos: number };
 
     if (global) {
-      data = await topWordleGlobal(message.author.id);
+      data = await topWordleGlobal(message.member);
     } else {
-      data = await topWordle(message.guild, message.author.id);
+      data = await topWordle(message.guild, message.member);
     }
 
     return show(
@@ -523,9 +523,9 @@ async function run(
     let data: { pages: Map<number, string[]>; pos: number };
 
     if (global) {
-      data = await topVoteStreakGlobal(message.author.id);
+      data = await topVoteStreakGlobal(message.member);
     } else {
-      data = await topVoteStreak(message.guild, message.author.id);
+      data = await topVoteStreak(message.guild, message.member);
     }
 
     return show(
@@ -541,9 +541,9 @@ async function run(
     let data: { pages: Map<number, string[]>; pos: number };
 
     if (global) {
-      data = await topVoteGlobal(message.author.id);
+      data = await topVoteGlobal(message.member);
     } else {
-      data = await topVote(message.guild, message.author.id);
+      data = await topVote(message.guild, message.member);
     }
 
     return show(
@@ -566,9 +566,9 @@ async function run(
     let data: { pages: Map<number, string[]>; pos: number };
 
     if (global) {
-      data = await topChatReactionGlobal(message.author.id, false);
+      data = await topChatReactionGlobal(message.member, false);
     } else {
-      data = await topChatReaction(message.guild, false, message.author.id);
+      data = await topChatReaction(message.guild, false, message.member);
     }
 
     return show(
@@ -586,9 +586,9 @@ async function run(
     let data: { pages: Map<number, string[]>; pos: number };
 
     if (global) {
-      data = await topChatReactionGlobal(message.author.id, true);
+      data = await topChatReactionGlobal(message.member, true);
     } else {
-      data = await topChatReaction(message.guild, true, message.author.id);
+      data = await topChatReaction(message.guild, true, message.member);
     }
 
     return show(
@@ -603,11 +603,11 @@ async function run(
 
     if (args.length === 1 || args[1]?.toLowerCase() === "global") {
       if (args[1]?.toLowerCase() === "global") {
-        data = await topCommandUsesGlobal(message.author.id);
+        data = await topCommandUsesGlobal(message.member);
         title = `top command uses [global]`;
         url = "https://nypsi.xyz/leaderboard/commands?ref=bot-lb";
       } else {
-        data = await topCommandUses(message.guild, message.author.id);
+        data = await topCommandUses(message.guild, message.member);
         title = `top command uses for ${message.guild.name}`;
       }
     } else {
@@ -623,9 +623,9 @@ async function run(
       if (args[2]?.toLowerCase() == "global") global = true;
 
       if (global) {
-        data = await topCommandGlobal(cmd, message.author.id);
+        data = await topCommandGlobal(cmd, message.member);
       } else {
-        data = await topCommand(message.guild, cmd, message.author.id);
+        data = await topCommand(message.guild, cmd, message.member);
       }
 
       title = `top ${(await getPrefix(message.guild))[0]}${cmd} uses ${
@@ -657,9 +657,9 @@ async function run(
     let data: { pages: Map<number, string[]>; pos: number };
 
     if (global) {
-      data = await topItemGlobal(selected.id, message.author.id);
+      data = await topItemGlobal(selected.id, message.member);
     } else {
-      data = await topItem(message.guild, selected.id, message.author.id);
+      data = await topItem(message.guild, selected.id, message.member);
     }
 
     return show(

--- a/src/commands/tower.ts
+++ b/src/commands/tower.ts
@@ -326,7 +326,7 @@ async function prepareGame(
 
   components[components.length - 1].components[0].setDisabled(true);
 
-  const desc = await renderGambleScreen(message.author.id, "playing", bet, "**0**x ($0)");
+  const desc = await renderGambleScreen("playing", bet, "**0**x ($0)");
 
   const embed = new CustomEmbed(message.member, desc)
     .setHeader("dragon tower", message.author.avatarURL())
@@ -531,7 +531,7 @@ async function playGame(
         percentChance(0.05) &&
         parseInt(await redis.get(`anticheat:interactivegame:count:${message.author.id}`)) > 100
       ) {
-        const res = await giveCaptcha(message.author.id);
+        const res = await giveCaptcha(message.member);
 
         if (res) {
           logger.info(
@@ -577,7 +577,7 @@ async function playGame(
       logger.info(
         `::cmd ${message.guild.id} ${message.channelId} ${message.author.username}: replaying tower`,
       );
-      if (await isLockedOut(message.author.id)) {
+      if (await isLockedOut(message.member)) {
         await verifyUser(message);
         return replay(embed, interaction, false);
       }
@@ -641,7 +641,6 @@ async function playGame(
     game.embed.setFooter({ text: `id: ${id}` });
     game.embed.setColor(Constants.EMBED_FAIL_COLOR);
     const desc = await renderGambleScreen(
-      message.author.id,
       "lose",
       game.bet,
       `**${game.win.toFixed(2)}**x ($${Math.round(game.bet * game.win).toLocaleString()})`,
@@ -661,7 +660,6 @@ async function playGame(
     }
 
     const desc = await renderGambleScreen(
-      message.author.id,
       "win",
       game.bet,
       `**${game.win.toFixed(2)}**x ($${Math.round(game.bet * game.win).toLocaleString()})`,
@@ -740,7 +738,6 @@ async function playGame(
     gamble(message.author, "tower", game.bet, "draw", id, game.bet);
     game.embed.setColor(flavors.macchiato.colors.yellow.hex as ColorResolvable);
     const desc = await renderGambleScreen(
-      message.author.id,
       "draw",
       game.bet,
       `**${game.win.toFixed(2)}**x ($${Math.round(game.bet * game.win).toLocaleString()})`,
@@ -787,7 +784,7 @@ async function playGame(
             await redis.set(Constants.redis.nypsi.GEM_GIVEN, "t", "EX", 86400);
             logger.info(`${message.author.id} received green_gem randomly (tower)`);
             addInventoryItem(message.member, "green_gem", 1);
-            addProgress(message.author.id, "gem_hunter", 1);
+            addProgress(message.member, "gem_hunter", 1);
             if (response.replied || response.deferred)
               response.followUp({
                 embeds: [
@@ -823,7 +820,6 @@ async function playGame(
         // });
 
         const desc = await renderGambleScreen(
-          message.author.id,
           "playing",
           game.bet,
           `**${game.win.toFixed(2)}**x ($${Math.round(game.bet * game.win).toLocaleString()})`,
@@ -831,7 +827,7 @@ async function playGame(
         game.embed.setDescription(desc);
 
         if (y >= 8) {
-          addProgress(message.author.id, "tower_pro", 1);
+          addProgress(message.member, "tower_pro", 1);
           win1(response);
           return;
         }

--- a/src/commands/trade.ts
+++ b/src/commands/trade.ts
@@ -98,7 +98,7 @@ async function run(
     }
   };
 
-  if (!(await userExists(message.author.id))) await createUser(message.author.id);
+  if (!(await userExists(message.member))) await createUser(message.member);
 
   if (message.client.user.id !== Constants.BOT_USER_ID && (await getAdminLevel(message.member)) < 1)
     return send({ embeds: [new ErrorEmbed("lol")] });
@@ -276,7 +276,7 @@ async function run(
           const item = res.fields.fields.get("item").value;
           let amount = res.fields.fields.get("amount").value;
 
-          inventory = await getInventory(message.author.id);
+          inventory = await getInventory(message.member);
 
           const selected = selectItem(item);
 
@@ -329,7 +329,7 @@ async function run(
 
           if (amount.toLowerCase() === "all") {
             await res.deferUpdate();
-            offeredMoney = await getBalance(message.author.id);
+            offeredMoney = await getBalance(message.member);
           } else if (!parseInt(amount) || isNaN(parseInt(amount)) || parseInt(amount) < 1) {
             await res.reply({
               embeds: [new ErrorEmbed("invalid amount")],
@@ -652,7 +652,7 @@ async function run(
 
         if (
           dayjs(tradeRequests[page].createdAt).isAfter(
-            dayjs().subtract((await isPremium(message.author.id)) ? 1 : 12, "hour"),
+            dayjs().subtract((await isPremium(message.member)) ? 1 : 12, "hour"),
           )
         ) {
           row.addComponents(

--- a/src/commands/unban.ts
+++ b/src/commands/unban.ts
@@ -16,8 +16,8 @@ import { getAllGroupAccountIds } from "../utils/functions/moderation/alts";
 import { newCase } from "../utils/functions/moderation/cases";
 
 import { deleteBan } from "../utils/functions/moderation/ban";
-import { getIdFromUsername, getLastKnownUsername } from "../utils/functions/users/tag";
 import { pluralize } from "../utils/functions/string";
+import { getIdFromUsername, getLastKnownUsername } from "../utils/functions/users/tag";
 
 const cmd = new Command("unban", "unban one or more users", "moderation").setPermissions([
   "BAN_MEMBERS",

--- a/src/commands/unmute.ts
+++ b/src/commands/unmute.ts
@@ -183,7 +183,7 @@ async function run(
 
   if (caseId) embed.setHeader(`unmute [${caseId}]`, message.guild.iconURL());
 
-  const ids = await getAllGroupAccountIds(message.guild, target.user.id);
+  const ids = await getAllGroupAccountIds(message.guild, target);
 
   let msg =
     punishAlts && ids.length > 3
@@ -277,7 +277,7 @@ async function doUnmute(
   }
   if (fail) return false;
 
-  await deleteMute(message.guild, target.user.id);
+  await deleteMute(message.guild, target);
   return await newCase(message.guild, "unmute", target.user.id, message.author, reason);
 }
 

--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -38,10 +38,10 @@ import {
 import { addWorkerUpgrade, getWorkers } from "../utils/functions/economy/workers";
 import { getPrefix } from "../utils/functions/guilds/utils";
 import PageManager from "../utils/functions/page";
+import { pluralize } from "../utils/functions/string";
 import { addTag, getTags } from "../utils/functions/users/tags";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 import { logger } from "../utils/logger";
-import { pluralize } from "../utils/functions/string";
 
 const itemFunctions = new Map<string, ItemUse>();
 
@@ -424,14 +424,14 @@ async function run(
 
     return send({ embeds: [embed] });
   } else if (selected.role === "tag") {
-    const tags = await getTags(message.author.id);
+    const tags = await getTags(message.member);
 
     if (tags.find((i) => i.tagId === selected.tagId))
       return send({ embeds: [new ErrorEmbed("you already have this tag")] });
 
     await removeInventoryItem(message.member, selected.id, 1);
 
-    await addTag(message.author.id, selected.tagId);
+    await addTag(message.member, selected.tagId);
 
     return send({
       embeds: [

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -145,7 +145,7 @@ async function run(
   if (msg) msg.edit({ embeds: [embed] });
   else message.channel.send({ embeds: [embed] });
 
-  addView(member.user.id, message.author.id, `user in ${message.guild.id}`);
+  addView(member, message.member, `user in ${message.guild.id}`);
 }
 
 cmd.setRun(run);

--- a/src/commands/vote.ts
+++ b/src/commands/vote.ts
@@ -17,8 +17,8 @@ import Constants from "../utils/Constants";
 import { getRawLevel } from "../utils/functions/economy/levelling";
 import { createUser, userExists } from "../utils/functions/economy/utils";
 import { getLastVote, getVoteStreak, hasVoted } from "../utils/functions/economy/vote";
-import { getDmSettings } from "../utils/functions/users/notifications";
 import { pluralize } from "../utils/functions/string";
+import { getDmSettings } from "../utils/functions/users/notifications";
 
 const cmd = new Command("vote", "vote every 12 hours to get rewards", "money");
 
@@ -57,7 +57,7 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
     }
   };
 
-  let level = await getRawLevel(message.author.id);
+  let level = await getRawLevel(message.member);
 
   if (level > 100) level = 100;
 
@@ -65,7 +65,7 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
 
   let xp = 15;
 
-  xp += Math.floor((await getRawLevel(message.author.id)) * 0.3);
+  xp += Math.floor((await getRawLevel(message.member)) * 0.3);
 
   if (xp > 100) xp = 100;
 
@@ -77,7 +77,7 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
       select: { monthVote: true, seasonVote: true },
     }),
     getDmSettings(message.member),
-    getVoteStreak(message.author.id),
+    getVoteStreak(message.member),
   ]);
 
   const embed = new CustomEmbed(message.member);

--- a/src/commands/weekly.ts
+++ b/src/commands/weekly.ts
@@ -36,10 +36,10 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
     return message.channel.send({ embeds: [embed] });
   };
 
-  if (!(await isPremium(message.author.id)) && !(await isBooster(message.author.id))) {
+  if (!(await isPremium(message.member)) && !(await isBooster(message.member))) {
     return notValidForYou();
   } else {
-    if ((await getTier(message.author.id)) < 2 && !(await isBooster(message.author.id))) {
+    if ((await getTier(message.member)) < 2 && !(await isBooster(message.member))) {
       return notValidForYou();
     }
 

--- a/src/commands/wordle.ts
+++ b/src/commands/wordle.ts
@@ -330,7 +330,7 @@ async function cancel(message: Message | (NypsiCommandInteraction & CommandInter
   games.delete(message.author.id);
 
   if (!message.member) return;
-  addWordleGame(message.author.id, false, game.guesses, performance.now() - game.start, game.word);
+  addWordleGame(message.member, false, game.guesses, performance.now() - game.start, game.word);
 }
 
 async function win(message: Message | (NypsiCommandInteraction & CommandInteraction), m: any) {
@@ -371,7 +371,7 @@ async function win(message: Message | (NypsiCommandInteraction & CommandInteract
       karmaCooldown.delete(message.author.id);
     }, ms("15m"));
 
-    await addKarma(message.author.id, 5);
+    await addKarma(message.member, 5);
   }
 }
 
@@ -398,7 +398,7 @@ async function lose(message: Message | (NypsiCommandInteraction & CommandInterac
   games.delete(message.author.id);
 
   if (!message.member) return;
-  addWordleGame(message.author.id, false, game.guesses, performance.now() - game.start, game.word);
+  addWordleGame(message.member, false, game.guesses, performance.now() - game.start, game.word);
 }
 
 function createBoard(): string[][] {

--- a/src/commands/work.ts
+++ b/src/commands/work.ts
@@ -58,7 +58,7 @@ async function run(message: NypsiMessage | (NypsiCommandInteraction & CommandInt
   const work = workMessages[Math.floor(Math.random() * workMessages.length)];
 
   await addBalance(message.member, earned);
-  addStat(message.author.id, "earned-work", earned);
+  addStat(message.member, "earned-work", earned);
 
   const embed = new CustomEmbed(message.member, work).setHeader("work", message.author.avatarURL());
 

--- a/src/commands/workers.ts
+++ b/src/commands/workers.ts
@@ -18,6 +18,7 @@ import {
 } from "discord.js";
 import { inPlaceSort } from "fast-sort";
 import prisma from "../init/database";
+import { NypsiClient } from "../models/Client";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders";
 import { Worker, WorkerByproducts } from "../types/Workers";
@@ -42,10 +43,9 @@ import {
   getWorker,
   getWorkers,
 } from "../utils/functions/economy/workers";
+import { pluralize } from "../utils/functions/string";
 import { addCooldown, getResponse, onCooldown } from "../utils/handlers/cooldownhandler";
 import { logger } from "../utils/logger";
-import { pluralize } from "../utils/functions/string";
-import { NypsiClient } from "../models/Client";
 import _ = require("lodash");
 
 const cmd = new Command(
@@ -331,7 +331,7 @@ async function run(
           return pageManager();
         } else {
           await removeBalance(message.member, baseWorkers[selected].cost);
-          addStat(message.author.id, "spent-workers", baseWorkers[selected].cost);
+          addStat(message.member, "spent-workers", baseWorkers[selected].cost);
           await addWorker(message.member, selected);
 
           userWorkers = await getWorkers(message.member);
@@ -512,7 +512,7 @@ async function run(
         }
 
         await removeBalance(message.member, cost);
-        addStat(message.author.id, "spent-workers", cost);
+        addStat(message.member, "spent-workers", cost);
         await addWorkerUpgrade(
           message.member,
           worker.id,
@@ -640,7 +640,7 @@ async function run(
           new CustomEmbed(
             message.member,
             `average yield for **${worker.id}** over ${value} ${pluralize("run", value)} ` +
-              `at ${(await getWorker(message.author.id, worker)).stored} ${worker.item_emoji} is **$${(totalEarned / value).toFixed(3)}**` +
+              `at ${(await getWorker(message.member, worker)).stored} ${worker.item_emoji} is **$${(totalEarned / value).toFixed(3)}**` +
               (totalByproducts.size > 0 ? " and:" : "") +
               byproductsDescription,
           ).setHeader("workers debug", message.author.avatarURL()),

--- a/src/commands/x.ts
+++ b/src/commands/x.ts
@@ -66,7 +66,7 @@ async function run(
   args: string[],
 ) {
   if (!(message instanceof Message)) return;
-  if ((await getAdminLevel(message.author.id)) < 1) {
+  if ((await getAdminLevel(message.member)) < 1) {
     if (message.member.roles.cache.has("1023950187661635605")) {
       if (args[0].toLowerCase() !== "review") {
         if (await redis.exists("nypsi:xemoji:cooldown")) return;
@@ -323,12 +323,12 @@ async function run(
       user.createdTimestamp / 1000,
     )}:R>\nadmin level: ${await getAdminLevel(user.id)}`;
 
-    if (!(await hasProfile(user.id))) desc += "\n**has no user profile**";
+    if (!(await hasProfile(user))) desc += "\n**has no user profile**";
 
-    if ((await isUserBlacklisted(user.id)).blacklisted) {
+    if ((await isUserBlacklisted(user)).blacklisted) {
       rows[3].components[1].setDisabled(true);
       desc += "\n**currently blacklisted**";
-    } else if ((await isEcoBanned(user.id)).banned) {
+    } else if ((await isEcoBanned(user)).banned) {
       desc += `\n**currently economy banned** - unbanned <t:${Math.floor((await getEcoBanTime(user.id)).getTime() / 1000)}:R>`;
     }
 
@@ -350,7 +350,7 @@ async function run(
       await res.deferReply();
 
       if (res.customId === "db-data") {
-        if ((await getAdminLevel(message.author.id)) < 1) {
+        if ((await getAdminLevel(message.member)) < 1) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **1** to do this")],
           });
@@ -366,13 +366,13 @@ async function run(
         await res.editReply({ files });
         return waitForButton();
       } else if (res.customId === "cmds") {
-        if ((await getAdminLevel(message.author.id)) < 1) {
+        if ((await getAdminLevel(message.member)) < 1) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **1** to do this")],
           });
           return waitForButton();
         }
-        const uses = await getCommandUses(user.id);
+        const uses = await getCommandUses(user);
         const total = uses.map((x) => x.uses).reduce((a, b) => a + b);
 
         const daily = parseInt(await redis.hget(Constants.redis.nypsi.TOP_COMMANDS_USER, user.id));
@@ -391,7 +391,7 @@ async function run(
         await res.editReply({ embeds: [embed] });
         return waitForButton();
       } else if (res.customId === "view-premium") {
-        if ((await getAdminLevel(message.author.id)) < 1) {
+        if ((await getAdminLevel(message.member)) < 1) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **1** to do this")],
           });
@@ -403,7 +403,7 @@ async function run(
         doPremium(user, res as ButtonInteraction);
         return waitForButton();
       } else if (res.customId === "set-admin") {
-        if ((await getAdminLevel(message.author.id)) < 69) {
+        if ((await getAdminLevel(message.member)) < 69) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **69** to do this")],
           });
@@ -428,7 +428,7 @@ async function run(
           await res.editReply({ embeds: [new CustomEmbed(message.member, "invalid value")] });
           return waitForButton();
         }
-        if (parseInt(msg.content) > (await getAdminLevel(message.author.id))) {
+        if (parseInt(msg.content) > (await getAdminLevel(message.member))) {
           await res.editReply({
             embeds: [
               new CustomEmbed(message.member, "nice try bozo ! suck this dick you wANK STAIN"),
@@ -439,11 +439,11 @@ async function run(
         logger.info(
           `admin: ${message.author.id} (${message.author.username}) updated ${user.id} admin level to ${msg.content}`,
         );
-        await setAdminLevel(user.id, parseInt(msg.content));
+        await setAdminLevel(user, parseInt(msg.content));
         await res.editReply({ embeds: [new CustomEmbed(message.member, "✅")] });
         return waitForButton();
       } else if (res.customId === "tags") {
-        if ((await getAdminLevel(message.author.id)) < 4) {
+        if ((await getAdminLevel(message.member)) < 4) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **4** to do this")],
           });
@@ -453,7 +453,7 @@ async function run(
         doTags(user, res as ButtonInteraction);
         return waitForButton();
       } else if (res.customId === "add-purchase") {
-        if ((await getAdminLevel(message.author.id)) < 4) {
+        if ((await getAdminLevel(message.member)) < 4) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **4** to do this")],
           });
@@ -502,7 +502,7 @@ async function run(
 
         msgResponse.first().react("✅");
       } else if (res.customId === "set-birthday") {
-        if ((await getAdminLevel(message.author.id)) < 1) {
+        if ((await getAdminLevel(message.member)) < 1) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **1** to do this")],
           });
@@ -538,11 +538,11 @@ async function run(
         logger.info(
           `admin: ${message.author.id} (${message.author.username}) set ${user.id} birthday to ${birthday}`,
         );
-        await setBirthday(user.id, birthday);
+        await setBirthday(user, birthday);
         msg.react("✅");
         return waitForButton();
       } else if (res.customId === "set-bal") {
-        if ((await getAdminLevel(message.author.id)) < 4) {
+        if ((await getAdminLevel(message.member)) < 4) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **4** to do this")],
           });
@@ -578,11 +578,11 @@ async function run(
         logger.info(
           `admin: ${message.author.id} (${message.author.username}) set ${user.id} balance to ${msg.content}`,
         );
-        await updateBalance(user.id, parseInt(msg.content));
+        await updateBalance(user, parseInt(msg.content));
         msg.react("✅");
         return waitForButton();
       } else if (res.customId === "set-bank") {
-        if ((await getAdminLevel(message.author.id)) < 4) {
+        if ((await getAdminLevel(message.member)) < 4) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **4** to do this")],
           });
@@ -618,11 +618,11 @@ async function run(
         logger.info(
           `admin: ${message.author.id} (${message.author.username}) set ${user.id} bank balance to ${msg.content}`,
         );
-        await updateBankBalance(user.id, parseInt(msg.content));
+        await updateBankBalance(user, parseInt(msg.content));
         msg.react("✅");
         return waitForButton();
       } else if (res.customId === "set-prestige") {
-        if ((await getAdminLevel(message.author.id)) < 4) {
+        if ((await getAdminLevel(message.member)) < 4) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **4** to do this")],
           });
@@ -653,11 +653,11 @@ async function run(
         logger.info(
           `admin: ${message.author.id} (${message.author.username}) set ${user.id} prestige to ${msg.content}`,
         );
-        await setPrestige(user.id, parseInt(msg.content));
+        await setPrestige(user, parseInt(msg.content));
         msg.react("✅");
         return waitForButton();
       } else if (res.customId === "set-level") {
-        if ((await getAdminLevel(message.author.id)) < 4) {
+        if ((await getAdminLevel(message.member)) < 4) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **4** to do this")],
           });
@@ -688,11 +688,11 @@ async function run(
         logger.info(
           `admin: ${message.author.id} (${message.author.username}) set ${user.id} level to ${msg.content}`,
         );
-        await setLevel(user.id, parseInt(msg.content));
+        await setLevel(user, parseInt(msg.content));
         msg.react("✅");
         return waitForButton();
       } else if (res.customId === "set-xp") {
-        if ((await getAdminLevel(message.author.id)) < 4) {
+        if ((await getAdminLevel(message.member)) < 4) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **4** to do this")],
           });
@@ -723,11 +723,11 @@ async function run(
         logger.info(
           `admin: ${message.author.id} (${message.author.username}) set ${user.id} xp to ${msg.content}`,
         );
-        await updateXp(user.id, parseInt(msg.content));
+        await updateXp(user, parseInt(msg.content));
         msg.react("✅");
         return waitForButton();
       } else if (res.customId === "set-inv") {
-        if ((await getAdminLevel(message.author.id)) < 4) {
+        if ((await getAdminLevel(message.member)) < 4) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **4** to do this")],
           });
@@ -790,20 +790,20 @@ async function run(
 
         if (mode === "set") {
           await setInventoryItem(
-            user.id,
+            user,
             msg.content.split(" ")[0],
             parseInt(msg.content.split(" ")[1]),
           );
         } else if (mode === "increment") {
-          await addInventoryItem(user.id, msg.content.split(" ")[0], amount);
+          await addInventoryItem(user, msg.content.split(" ")[0], amount);
         } else if (mode === "decrement") {
-          await removeInventoryItem(user.id, msg.content.split(" ")[0], amount);
+          await removeInventoryItem(user, msg.content.split(" ")[0], amount);
         }
 
         msg.react("✅");
         return waitForButton();
       } else if (res.customId === "set-karma") {
-        if ((await getAdminLevel(message.author.id)) < 4) {
+        if ((await getAdminLevel(message.member)) < 4) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **4** to do this")],
           });
@@ -831,7 +831,7 @@ async function run(
           return waitForButton();
         }
 
-        const karma = await getKarma(user.id);
+        const karma = await getKarma(user);
 
         let amount = 0;
         let remove = false;
@@ -847,24 +847,24 @@ async function run(
           `admin: ${message.author.id} (${message.author.username}) set ${user.id} karma to ${msg.content}`,
         );
 
-        if (remove) await removeKarma(user.id, amount);
-        else await addKarma(user.id, amount);
+        if (remove) await removeKarma(user, amount);
+        else await addKarma(user, amount);
 
         msg.react("✅");
         return waitForButton();
       } else if (res.customId === "ecoban") {
-        if ((await getAdminLevel(message.author.id)) < 2) {
+        if ((await getAdminLevel(message.member)) < 2) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **2** to do this")],
           });
           return waitForButton();
         }
 
-        if ((await isEcoBanned(user.id)).banned) {
+        if ((await isEcoBanned(user)).banned) {
           logger.info(
             `admin: ${message.author.id} (${message.author.username}) removed ecoban for ${user.id} `,
           );
-          await setEcoBan(user.id);
+          await setEcoBan(user);
           await res.editReply({ embeds: [new CustomEmbed(message.member, "removed ecoban")] });
           return;
         }
@@ -896,7 +896,7 @@ async function run(
         logger.info(
           `admin: ${message.author.id} (${message.author.username}) set ${user.id} ecoban to ${msg.content}`,
         );
-        await setEcoBan(user.id, time);
+        await setEcoBan(user, time);
         msg.react("✅");
         return waitForButton();
       } else if (res.customId === "blacklist") {
@@ -907,23 +907,23 @@ async function run(
           return waitForButton();
         }
 
-        if ((await isUserBlacklisted(user.id)).blacklisted) {
+        if ((await isUserBlacklisted(user)).blacklisted) {
           logger.info(
             `admin: ${message.author.id} (${message.author.username}) removed blacklist for ${user.id} `,
           );
-          await setUserBlacklist(user.id, false);
+          await setUserBlacklist(user, false);
           await res.editReply({ embeds: [new CustomEmbed(message.member, "user unblacklisted")] });
           return waitForButton();
         } else {
           logger.info(
             `admin: ${message.author.id} (${message.author.username}) added blacklist for ${user.id} `,
           );
-          await setUserBlacklist(user.id, true);
+          await setUserBlacklist(user, true);
           await res.editReply({ embeds: [new CustomEmbed(message.member, "user blacklisted")] });
           return waitForButton();
         }
       } else if (res.customId === "ac") {
-        if ((await getAdminLevel(message.author.id)) < 1) {
+        if ((await getAdminLevel(message.member)) < 1) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **1** to do this")],
           });
@@ -935,7 +935,7 @@ async function run(
         doAnticheat(user, res as ButtonInteraction);
         return waitForButton();
       } else if (res.customId === "wipe") {
-        if ((await getAdminLevel(message.author.id)) < 69) {
+        if ((await getAdminLevel(message.member)) < 69) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **69** to do this")],
           });
@@ -1132,10 +1132,10 @@ async function run(
 
       const embed = new CustomEmbed(message.member);
 
-      if (await isPremium(user.id)) {
+      if (await isPremium(user)) {
         const [profile, aliases] = await Promise.all([
-          getPremiumProfile(user.id),
-          getUserAliases(user.id),
+          getPremiumProfile(user),
+          getUserAliases(user),
         ]);
 
         rows[0].components[0].setDisabled(true);
@@ -1177,14 +1177,14 @@ async function run(
       await res.deferReply();
 
       if (res.customId === "add-premium") {
-        if ((await getAdminLevel(message.author.id)) < 5) {
+        if ((await getAdminLevel(message.member)) < 5) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **5** to do this")],
           });
           return waitForButton();
         }
 
-        if (await isPremium(user.id)) {
+        if (await isPremium(user)) {
           await res.editReply({ embeds: [new ErrorEmbed("idiot bro")] });
           return waitForButton();
         }
@@ -1220,18 +1220,18 @@ async function run(
           `admin: ${message.author.id} (${message.author.username}) added ${user.id} premium at level ${msg.content}`,
         );
 
-        await addMember(user.id, parseInt(msg.content));
+        await addMember(user, parseInt(msg.content));
         msg.react("✅");
         return waitForButton();
       } else if (res.customId === "set-tier") {
-        if ((await getAdminLevel(message.author.id)) < 5) {
+        if ((await getAdminLevel(message.member)) < 5) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **5** to do this")],
           });
           return waitForButton();
         }
 
-        if (!(await isPremium(user.id))) {
+        if (!(await isPremium(user))) {
           await res.editReply({ embeds: [new ErrorEmbed("idiot bro")] });
           return waitForButton();
         }
@@ -1267,18 +1267,18 @@ async function run(
           `admin: ${message.author.id} (${message.author.username}) set ${user.id} premium tier to ${msg.content}`,
         );
 
-        await setTier(user.id, parseInt(msg.content));
+        await setTier(user, parseInt(msg.content));
         msg.react("✅");
         return waitForButton();
       } else if (res.customId === "set-expire") {
-        if ((await getAdminLevel(message.author.id)) < 5) {
+        if ((await getAdminLevel(message.member)) < 5) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **5** to do this")],
           });
           return waitForButton();
         }
 
-        if (!(await isPremium(user.id))) {
+        if (!(await isPremium(user))) {
           await res.editReply({ embeds: [new ErrorEmbed("idiot bro")] });
           return waitForButton();
         }
@@ -1318,11 +1318,11 @@ async function run(
           } premium expire date to ${date.format()}`,
         );
 
-        await setExpireDate(user.id, date.toDate());
+        await setExpireDate(user, date.toDate());
         msg.react("✅");
         return waitForButton();
       } else if (res.customId === "raw-data") {
-        if ((await getAdminLevel(message.author.id)) < 1) {
+        if ((await getAdminLevel(message.member)) < 1) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **1** to do this")],
           });
@@ -1331,7 +1331,7 @@ async function run(
         logger.info(
           `admin: ${message.author.id} (${message.author.username}) viewed ${user.id} raw premium data`,
         );
-        const profile = await getPremiumProfile(user.id);
+        const profile = await getPremiumProfile(user);
         await res.editReply({
           embeds: [
             new CustomEmbed(message.member, `\`\`\`${JSON.stringify(profile, null, 2)}\`\`\``),
@@ -1370,7 +1370,7 @@ async function run(
         });
         return waitForButton();
       } else if (res.customId === "expire-now") {
-        if ((await getAdminLevel(message.author.id)) < 5) {
+        if ((await getAdminLevel(message.member)) < 5) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **5** to do this")],
           });
@@ -1379,18 +1379,18 @@ async function run(
         logger.info(
           `admin: ${message.author.id} (${message.author.username}) set ${user.id} expire to now`,
         );
-        await expireUser(user.id, message.client as NypsiClient);
+        await expireUser(user, message.client as NypsiClient);
         await res.editReply({ embeds: [new CustomEmbed(message.member, "done sir.")] });
         return waitForButton();
       } else if (res.customId === "set-credits") {
-        if ((await getAdminLevel(message.author.id)) < 5) {
+        if ((await getAdminLevel(message.member)) < 5) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **5** to do this")],
           });
           return waitForButton();
         }
 
-        if (!(await isPremium(user.id))) {
+        if (!(await isPremium(user))) {
           await res.editReply({ embeds: [new ErrorEmbed("idiot bro")] });
           return waitForButton();
         }
@@ -1426,7 +1426,7 @@ async function run(
           `admin: ${message.author.id} (${message.author.username}) set ${user.id} premium credits to ${msg.content}`,
         );
 
-        await setCredits(user.id, parseInt(msg.content));
+        await setCredits(user, parseInt(msg.content));
         msg.react("✅");
         return waitForButton();
       }
@@ -1485,7 +1485,7 @@ async function run(
       await res.deferReply();
 
       if (res.customId === "ac-hist") {
-        if ((await getAdminLevel(message.author.id)) < 2) {
+        if ((await getAdminLevel(message.member)) < 2) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **2** to do this")],
           });
@@ -1541,21 +1541,21 @@ async function run(
         await res.editReply({ content: "✅" });
         return waitForButton();
       } else if (res.customId === "give-captcha") {
-        if ((await getAdminLevel(res.user.id)) < 1) {
+        if ((await getAdminLevel(res.user)) < 1) {
           res.followUp({ embeds: [new ErrorEmbed("you require admin level 1 for this")] });
           return;
         }
 
         logger.info(
-          `admin: ${message.author.id} (${message.author.username}) gave ${user.id} captcha`,
+          `admin: ${message.author.id} (${message.author.username}) gave ${user} captcha`,
         );
 
-        await giveCaptcha(user.id, 2, true);
+        await giveCaptcha(user, 2, true);
 
         res.followUp({ content: "✅" });
         return waitForButton();
       } else if (res.customId === "captcha-hist") {
-        if ((await getAdminLevel(res.user.id)) < 3) {
+        if ((await getAdminLevel(res.user)) < 3) {
           res.followUp({ embeds: [new ErrorEmbed("you require admin level 3 for this")] });
           return;
         }
@@ -1564,7 +1564,7 @@ async function run(
           `admin: ${message.author.id} (${message.author.username}) viewed ${user.id} captcha history`,
         );
 
-        const history = await getCaptchaHistory(user.id);
+        const history = await getCaptchaHistory(user);
 
         const embed = new CustomEmbed(message.member);
 
@@ -1625,7 +1625,7 @@ async function run(
 
     const embed = new CustomEmbed(message.member);
 
-    let tags = await getTags(user.id);
+    let tags = await getTags(user);
 
     embed.setDescription(
       `${tags.length > 0 ? `\`${tags.map((i) => i.tagId).join("` `")}\`` : "no tags"}`,
@@ -1645,7 +1645,7 @@ async function run(
       await res.deferReply();
 
       if (res.customId === "add-tag") {
-        if ((await getAdminLevel(message.author.id)) < 4) {
+        if ((await getAdminLevel(message.member)) < 4) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **4** to do this")],
           });
@@ -1671,7 +1671,7 @@ async function run(
           `admin: ${message.author.id} (${message.author.username}) added ${msgResponse.content} tag to ${user.id}`,
         );
 
-        tags = await addTag(user.id, msgResponse.content);
+        tags = await addTag(user, msgResponse.content);
 
         msgResponse.react("✅");
         await msg.edit({
@@ -1684,7 +1684,7 @@ async function run(
         });
         return waitForButton();
       } else if (res.customId === "remove-tag") {
-        if ((await getAdminLevel(message.author.id)) < 4) {
+        if ((await getAdminLevel(message.member)) < 4) {
           await res.editReply({
             embeds: [new ErrorEmbed("you require admin level **4** to do this")],
           });
@@ -1710,7 +1710,7 @@ async function run(
           `admin: ${message.author.id} (${message.author.username}) removed ${msgResponse.content} tag from ${user.id}`,
         );
 
-        tags = await removeTag(user.id, msgResponse.content);
+        tags = await removeTag(user, msgResponse.content);
 
         msgResponse.react("✅");
         await msg.edit({
@@ -1789,17 +1789,17 @@ async function run(
   };
 
   const requestProfileTransfer = async (from: User, to: User) => {
-    if ((await getAdminLevel(message.author.id)) !== 69)
+    if ((await getAdminLevel(message.member)) !== 69)
       return message.channel.send({
         embeds: [new ErrorEmbed("lol xd xdxddxd ahahhaha YOURE GAY dont even TRY")],
       });
 
-    if (await hasProfile(to.id))
+    if (await hasProfile(to))
       return message.channel.send({
         embeds: [new ErrorEmbed(`${to.username} has a nypsi profile, ask them to do /data delete`)],
       });
 
-    if (!(await hasProfile(from.id)))
+    if (!(await hasProfile(from)))
       return message.channel.send({
         embeds: [new ErrorEmbed(`${from.username} doesn't have a nypsi profile you fucking idiot`)],
       });
@@ -1879,7 +1879,7 @@ async function run(
 
     return requestProfileTransfer(fromUser, toUser);
   } else if (args[0].toLowerCase() === "drop") {
-    if ((await getAdminLevel(message.author.id)) < 5) {
+    if ((await getAdminLevel(message.member)) < 5) {
       return message.channel.send({
         embeds: [new ErrorEmbed("you require admin level **5** to do this")],
       });

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -74,7 +74,7 @@ export default async function guildMemberAdd(member: GuildMember) {
 
   const [persistentRoles, userRoles] = await Promise.all([
     getPersistentRoles(member.guild),
-    getPersistentRolesForUser(member.guild, member.id),
+    getPersistentRolesForUser(member.guild, member),
   ]);
 
   if (userRoles.length > 0 && persistentRoles.length > 0) {

--- a/src/models/EmbedBuilders.ts
+++ b/src/models/EmbedBuilders.ts
@@ -1,5 +1,6 @@
-import { ColorResolvable, EmbedBuilder, GuildMember } from "discord.js";
+import { ColorResolvable, EmbedBuilder } from "discord.js";
 import Constants from "../utils/Constants";
+import { getUserId, MemberResolvable } from "../utils/functions/member";
 import { getEmbedColor } from "../utils/functions/premium/color";
 import { logger } from "../utils/logger";
 import ms = require("ms");
@@ -19,13 +20,13 @@ setInterval(() => {
 }, ms("1 hour"));
 
 export class CustomEmbed extends EmbedBuilder {
-  constructor(member?: GuildMember | string, text?: string, disableFooter = false) {
+  constructor(member?: MemberResolvable, text?: string, disableFooter = false) {
     super();
 
     super.setColor(Constants.PURPLE);
 
     if (member) {
-      super.setColor(getColor(typeof member === "string" ? member : member.id));
+      super.setColor(getColor(member));
     }
 
     if (text) {
@@ -212,14 +213,16 @@ export class ErrorEmbed extends EmbedBuilder {
   }
 }
 
-export function getColor(id: string): ColorResolvable {
-  (async () => {
-    const color = await getEmbedColor(id);
+export function getColor(member: MemberResolvable): ColorResolvable {
+  const userId = getUserId(member);
 
-    colorCache.set(id, color);
+  (async () => {
+    const color = await getEmbedColor(userId);
+
+    colorCache.set(userId, color);
   })();
-  if (colorCache.has(id)) {
-    if (colorCache.get(id) === "default") return Constants.PURPLE;
-    else return colorCache.get(id) as ColorResolvable;
+  if (colorCache.has(userId)) {
+    if (colorCache.get(userId) === "default") return Constants.PURPLE;
+    else return colorCache.get(userId) as ColorResolvable;
   } else return Constants.PURPLE;
 }

--- a/src/utils/functions/economy/loot_pools.ts
+++ b/src/utils/functions/economy/loot_pools.ts
@@ -1,8 +1,9 @@
-import { GuildMember } from "discord.js";
 import { Item } from "../../../types/Economy";
 import { LootPool, LootPoolItemEntry, LootPoolResult } from "../../../types/LootPool";
 import { logger } from "../../logger";
 import { addKarma } from "../karma/karma";
+import { MemberResolvable } from "../member";
+import { pluralize } from "../string";
 import { addProgress } from "./achievements";
 import { addBalance } from "./balance";
 import { addToGuildXP, getGuildName } from "./guilds";
@@ -15,7 +16,6 @@ import {
 } from "./inventory";
 import { getItems, getLootPools } from "./utils";
 import { addXp } from "./xp";
-import { pluralize } from "../string";
 
 export function getDefaultLootPool(predicate?: (item: Item) => boolean): LootPool {
   const lootPool: LootPool = {
@@ -45,7 +45,7 @@ export function getDefaultLootPool(predicate?: (item: Item) => boolean): LootPoo
   return lootPool;
 }
 
-export async function giveLootPoolResult(member: string | GuildMember, result: LootPoolResult) {
+export async function giveLootPoolResult(member: MemberResolvable, result: LootPoolResult) {
   if (Object.hasOwn(result, "money")) {
     await addBalance(member, result.money);
   }
@@ -205,10 +205,7 @@ function getItemCount(data: LootPoolItemEntry, itemId: string): number {
   return Math.floor(Math.random() * (data.count.max - data.count.min + 1) + data.count.min);
 }
 
-export async function openCrate(
-  member: GuildMember | string,
-  item: Item,
-): Promise<LootPoolResult[]> {
+export async function openCrate(member: MemberResolvable, item: Item): Promise<LootPoolResult[]> {
   const inventory = await getInventory(member);
 
   if (!inventory.has(item.id) || !Object.hasOwn(item, "loot_pools")) {

--- a/src/utils/functions/economy/lottery.ts
+++ b/src/utils/functions/economy/lottery.ts
@@ -1,4 +1,5 @@
 import prisma from "../../../init/database";
+import { getUserId, MemberResolvable } from "../member";
 import { getItems } from "./utils";
 
 export async function getApproximatePrizePool() {
@@ -32,10 +33,10 @@ export async function getTicketCount() {
   return Number(query._sum.amount);
 }
 
-export async function getDailyLottoTickets(userId: string) {
+export async function getDailyLottoTickets(member: MemberResolvable) {
   const query = await prisma.economy.findUnique({
     where: {
-      userId,
+      userId: getUserId(member),
     },
     select: {
       dailyLottery: true,
@@ -45,10 +46,10 @@ export async function getDailyLottoTickets(userId: string) {
   return query.dailyLottery;
 }
 
-export async function setDailyLotteryTickets(userId: string, amount: number) {
+export async function setDailyLotteryTickets(member: MemberResolvable, amount: number) {
   await prisma.economy.update({
     where: {
-      userId,
+      userId: getUserId(member),
     },
     data: {
       dailyLottery: amount,

--- a/src/utils/functions/economy/offers.ts
+++ b/src/utils/functions/economy/offers.ts
@@ -14,6 +14,7 @@ import { NypsiClient } from "../../../models/Client";
 import { CustomEmbed } from "../../../models/EmbedBuilders";
 import Constants from "../../Constants";
 import { logger } from "../../logger";
+import { getUserId, MemberResolvable } from "../member";
 import { filterOutliers } from "../outliers";
 import { isPremium } from "../premium/premium";
 import { getTax } from "../tax";
@@ -94,25 +95,31 @@ export async function createOffer(
   return true;
 }
 
-export async function getOwnedOffers(userId: string) {
-  return await prisma.offer.findMany({ where: { AND: [{ ownerId: userId }, { sold: false }] } });
+export async function getOwnedOffers(member: MemberResolvable) {
+  return await prisma.offer.findMany({
+    where: { AND: [{ ownerId: getUserId(member) }, { sold: false }] },
+  });
 }
 
-export async function getTargetedOffers(userId: string) {
-  return await prisma.offer.findMany({ where: { AND: [{ targetId: userId }, { sold: false }] } });
+export async function getTargetedOffers(member: MemberResolvable) {
+  return await prisma.offer.findMany({
+    where: { AND: [{ targetId: getUserId(member) }, { sold: false }] },
+  });
 }
 
-export async function getBlockedList(userId: string) {
+export async function getBlockedList(member: MemberResolvable) {
+  const userId = getUserId(member);
+
   if (!(await userExists(userId))) await createUser(userId);
 
   return await prisma.economy
-    .findUnique({ where: { userId: userId }, select: { offersBlock: true } })
+    .findUnique({ where: { userId }, select: { offersBlock: true } })
     .then((r) => r.offersBlock);
 }
 
-export async function setBlockedList(userId: string, list: string[]) {
+export async function setBlockedList(member: MemberResolvable, list: string[]) {
   return await prisma.economy
-    .update({ where: { userId: userId }, data: { offersBlock: list } })
+    .update({ where: { userId: getUserId(member) }, data: { offersBlock: list } })
     .then((r) => r.offersBlock);
 }
 

--- a/src/utils/functions/economy/trade_requests.ts
+++ b/src/utils/functions/economy/trade_requests.ts
@@ -1,4 +1,5 @@
 import { TradeRequest } from "@prisma/client";
+import { ClusterManager } from "discord-hybrid-sharding";
 import {
   ActionRowBuilder,
   ButtonBuilder,
@@ -16,6 +17,7 @@ import { CustomEmbed, ErrorEmbed } from "../../../models/EmbedBuilders";
 import { Item } from "../../../types/Economy";
 import Constants from "../../Constants";
 import { logger, transactionMulti } from "../../logger";
+import { getUserId, MemberResolvable } from "../member";
 import { getAllGroupAccountIds } from "../moderation/alts";
 import { getTier, isPremium } from "../premium/premium";
 import { addToNypsiBank, getTax } from "../tax";
@@ -25,21 +27,13 @@ import { addInventoryItem, getInventory, isGem, removeInventoryItem } from "./in
 import { createUser, getItems, userExists } from "./utils";
 import ms = require("ms");
 import dayjs = require("dayjs");
-import { ClusterManager } from "discord-hybrid-sharding";
 
 const beingFulfilled = new Set<number>();
 
-export async function getTradeRequests(member: GuildMember | string) {
-  let id: string;
-  if (member instanceof GuildMember) {
-    id = member.user.id;
-  } else {
-    id = member;
-  }
-
+export async function getTradeRequests(member: MemberResolvable) {
   const query = await prisma.tradeRequest.findMany({
     where: {
-      AND: [{ ownerId: id }, { completed: false }],
+      AND: [{ ownerId: getUserId(member) }, { completed: false }],
     },
     orderBy: {
       createdAt: "asc",

--- a/src/utils/functions/guilds/christmas.ts
+++ b/src/utils/functions/guilds/christmas.ts
@@ -166,7 +166,15 @@ export async function getChristmasCountdown(guild: Guild) {
   return query;
 }
 
-export async function setChristmasCountdown(guild: Guild, xmas: any) {
+export async function setChristmasCountdown(
+  guild: Guild,
+  xmas: {
+    guildId: string;
+    channel: string;
+    enabled: boolean;
+    format: string;
+  },
+) {
   await prisma.guildChristmas.update({
     where: {
       guildId: guild.id,

--- a/src/utils/functions/guilds/roles.ts
+++ b/src/utils/functions/guilds/roles.ts
@@ -1,5 +1,6 @@
 import { Guild } from "discord.js";
 import prisma from "../../../init/database";
+import { getUserId, MemberResolvable } from "../member";
 import ms = require("ms");
 
 const autoRoleCache = new Map<string, string[]>();
@@ -66,13 +67,15 @@ export async function setPersistentRoles(guild: Guild, roles: string[]) {
   persistentRoleCache.delete(guild.id);
 }
 
-export async function getPersistentRolesForUser(guild: Guild, userId: string) {
+export async function getPersistentRolesForUser(guild: Guild, member: MemberResolvable) {
+  const userId = getUserId(member);
+
   const query: string[] = await prisma.rolePersist
     .findUnique({
       where: {
         guildId_userId: {
           guildId: guild.id,
-          userId: userId,
+          userId,
         },
       },
       select: {
@@ -87,7 +90,7 @@ export async function getPersistentRolesForUser(guild: Guild, userId: string) {
       where: {
         guildId_userId: {
           guildId: guild.id,
-          userId: userId,
+          userId,
         },
       },
     });

--- a/src/utils/functions/member.ts
+++ b/src/utils/functions/member.ts
@@ -1,4 +1,4 @@
-import { Collection, Guild, GuildMember, Role } from "discord.js";
+import { APIInteractionGuildMember, Collection, Guild, GuildMember, Role, User } from "discord.js";
 import { inPlaceSort, sort } from "fast-sort";
 import { compareTwoStrings } from "string-similarity";
 import Constants from "../Constants";
@@ -227,4 +227,12 @@ export async function getRole(guild: Guild, roleName: string): Promise<Role> {
   }
 
   return target;
+}
+
+export type MemberResolvable = GuildMember | APIInteractionGuildMember | User | string;
+
+export function getUserId(user: MemberResolvable): string {
+    if (typeof user === "string") return user;
+    if (typeof (user as any).id === "string") return (user as any).id;
+    return (user as APIInteractionGuildMember).user.id;
 }

--- a/src/utils/functions/moderation/alts.ts
+++ b/src/utils/functions/moderation/alts.ts
@@ -2,6 +2,7 @@ import { Guild } from "discord.js";
 import prisma from "../../../init/database";
 import redis from "../../../init/redis";
 import Constants from "../../Constants";
+import { getUserId, MemberResolvable } from "../member";
 import ms = require("ms");
 
 export async function addAlt(guild: Guild, mainId: string, altId: string) {
@@ -42,7 +43,8 @@ export async function deleteAlt(guild: Guild, altId: string) {
   for (const alt of alts) await redis.del(`${Constants.redis.cache.guild.ALTS}:${guild.id}:${alt}`);
 }
 
-export async function getAlts(guild: Guild | string, mainId: string) {
+export async function getAlts(guild: Guild | string, member: MemberResolvable) {
+  const mainId = getUserId(member);
   let id: string;
 
   if (guild instanceof Guild) id = guild.id;
@@ -69,7 +71,9 @@ export async function getAlts(guild: Guild | string, mainId: string) {
   return query.map((i) => i.altId);
 }
 
-export async function getAllGroupAccountIds(guild: Guild | string, userId: string) {
+export async function getAllGroupAccountIds(guild: Guild | string, member: MemberResolvable) {
+  const userId = getUserId(member);
+
   let id: string;
 
   if (guild instanceof Guild) id = guild.id;

--- a/src/utils/functions/moderation/cases.ts
+++ b/src/utils/functions/moderation/cases.ts
@@ -1,6 +1,7 @@
 import { Guild, User } from "discord.js";
 import prisma from "../../../init/database";
 import { PunishmentType } from "../../../types/Moderation";
+import { getUserId, MemberResolvable } from "../member";
 import { addModLog, isModLogsEnabled } from "./logs";
 
 export async function getCaseCount(guild: Guild) {
@@ -71,10 +72,10 @@ export async function restoreCase(guild: Guild, caseId: number) {
   });
 }
 
-export async function getCases(guild: Guild, userID: string) {
+export async function getCases(guild: Guild, member: MemberResolvable) {
   const query = await prisma.moderationCase.findMany({
     where: {
-      AND: [{ guildId: guild.id }, { user: userID }],
+      AND: [{ guildId: guild.id }, { user: getUserId(member) }],
     },
     include: {
       evidence: {

--- a/src/utils/functions/news.ts
+++ b/src/utils/functions/news.ts
@@ -1,5 +1,6 @@
 import redis from "../../init/redis";
 import Constants from "../Constants";
+import { getUserId, MemberResolvable } from "./member";
 
 type News = {
   text: string;
@@ -27,10 +28,10 @@ export async function setNews(string: string) {
   );
 }
 
-export async function hasSeenNews(id: string) {
+export async function hasSeenNews(member: MemberResolvable) {
   if (!(await redis.exists(Constants.redis.nypsi.NEWS_SEEN))) return null;
 
-  const index = await redis.lpos(Constants.redis.nypsi.NEWS_SEEN, id);
+  const index = await redis.lpos(Constants.redis.nypsi.NEWS_SEEN, getUserId(member));
 
   if (index == null) return null;
 

--- a/src/utils/functions/tmdb.ts
+++ b/src/utils/functions/tmdb.ts
@@ -1,5 +1,4 @@
 import ms = require("ms");
-import { GuildMember } from "discord.js";
 import prisma from "../../init/database";
 import redis from "../../init/redis";
 import {
@@ -12,6 +11,7 @@ import {
 } from "../../types/tmdb";
 import Constants from "../Constants";
 import { addTaskProgress } from "./economy/tasks";
+import { getUserId, MemberResolvable } from "./member";
 
 const BASE = "https://api.themoviedb.org/3";
 
@@ -224,18 +224,13 @@ function transformProviders(providerData: any): CountryProvider[] {
 }
 
 export async function setUserRating(
-  member: GuildMember | string,
+  member: MemberResolvable,
   type: "movie" | "tv",
   id: number,
   name: string,
   rating: number | "reset",
 ) {
-  let userId: string;
-  if (member instanceof GuildMember) {
-    userId = member.user.id;
-  } else {
-    userId = member;
-  }
+  const userId = getUserId(member);
 
   if (rating == "reset") {
     return await prisma.tmdbRatings.deleteMany({ where: { userId, type, id } });
@@ -270,25 +265,16 @@ export async function getRating(type: "movie" | "tv", id: number) {
 }
 
 export async function getUserRatings(
-  member: GuildMember | string,
+  member: MemberResolvable,
   type: "movie" | "tv",
   id: number,
 ): Promise<number>;
 export async function getUserRatings(
-  member: GuildMember | string,
+  member: MemberResolvable,
   type?: "movie" | "tv",
 ): Promise<{ name: string; rating: number }[]>;
-export async function getUserRatings(
-  member: GuildMember | string,
-  type?: "movie" | "tv",
-  id?: number,
-) {
-  let userId: string;
-  if (member instanceof GuildMember) {
-    userId = member.user.id;
-  } else {
-    userId = member;
-  }
+export async function getUserRatings(member: MemberResolvable, type?: "movie" | "tv", id?: number) {
+  const userId = getUserId(member);
 
   if (id)
     return (

--- a/src/utils/functions/users/admin.ts
+++ b/src/utils/functions/users/admin.ts
@@ -2,15 +2,10 @@ import ms = require("ms");
 import prisma from "../../../init/database";
 import redis from "../../../init/redis";
 import Constants from "../../Constants";
-import { GuildMember } from "discord.js";
+import { getUserId, MemberResolvable } from "../member";
 
-export async function getAdminLevel(member: GuildMember | string) {
-  let userId: string;
-  if (member instanceof GuildMember) {
-    userId = member.user.id;
-  } else {
-    userId = member;
-  }
+export async function getAdminLevel(member: MemberResolvable) {
+  const userId = getUserId(member);
 
   if (await redis.exists(`${Constants.redis.cache.user.ADMIN_LEVEL}:${userId}`)) {
     return parseInt(await redis.get(`${Constants.redis.cache.user.ADMIN_LEVEL}:${userId}`));
@@ -41,7 +36,9 @@ export async function getAdminLevel(member: GuildMember | string) {
   return query.adminLevel;
 }
 
-export async function setAdminLevel(userId: string, level: number) {
+export async function setAdminLevel(member: MemberResolvable, level: number) {
+  const userId = getUserId(member);
+
   await redis.del(`${Constants.redis.cache.user.ADMIN_LEVEL}:${userId}`);
   await prisma.user.update({
     where: {

--- a/src/utils/functions/users/birthday.ts
+++ b/src/utils/functions/users/birthday.ts
@@ -3,28 +3,35 @@ import { sort } from "fast-sort";
 import prisma from "../../../init/database";
 import redis from "../../../init/redis";
 import Constants from "../../Constants";
+import { getUserId, MemberResolvable } from "../member";
 
-export async function getBirthday(userId: string) {
-  const query = await prisma.user.findUnique({ where: { id: userId }, select: { birthday: true } });
+export async function getBirthday(member: MemberResolvable) {
+  const query = await prisma.user.findUnique({
+    where: { id: getUserId(member) },
+    select: { birthday: true },
+  });
 
   return query.birthday;
 }
 
-export async function setBirthday(userId: string, birthday: Date) {
-  await prisma.user.update({ where: { id: userId }, data: { birthday } });
+export async function setBirthday(member: MemberResolvable, birthday: Date) {
+  await prisma.user.update({ where: { id: getUserId(member) }, data: { birthday } });
 }
 
-export async function isBirthdayEnabled(userId: string) {
+export async function isBirthdayEnabled(member: MemberResolvable) {
   const query = await prisma.user.findUnique({
-    where: { id: userId },
+    where: { id: getUserId(member) },
     select: { birthdayAnnounce: true },
   });
 
   return query.birthdayAnnounce;
 }
 
-export async function setBirthdayEnabled(userId: string, enabled: boolean) {
-  await prisma.user.update({ where: { id: userId }, data: { birthdayAnnounce: enabled } });
+export async function setBirthdayEnabled(member: MemberResolvable, enabled: boolean) {
+  await prisma.user.update({
+    where: { id: getUserId(member) },
+    data: { birthdayAnnounce: enabled },
+  });
 }
 
 export async function getTodaysBirthdays(useCache = true) {

--- a/src/utils/functions/users/marriage.ts
+++ b/src/utils/functions/users/marriage.ts
@@ -1,16 +1,11 @@
 import { Marriage } from "@prisma/client";
-import { GuildMember } from "discord.js";
 import prisma from "../../../init/database";
 import redis from "../../../init/redis";
 import Constants from "../../Constants";
+import { getUserId, MemberResolvable } from "../member";
 
-export async function isMarried(member: GuildMember | string): Promise<false | Marriage> {
-  let userId: string;
-  if (member instanceof GuildMember) {
-    userId = member.user.id;
-  } else {
-    userId = member;
-  }
+export async function isMarried(member: MemberResolvable): Promise<false | Marriage> {
+  const userId = getUserId(member);
 
   const cache = await redis.get(`${Constants.redis.cache.user.MARRIED}:${userId}`);
 
@@ -50,13 +45,8 @@ export async function addMarriage(userId: string, targetId: string) {
   );
 }
 
-export async function removeMarriage(member: GuildMember | string) {
-  let userId: string;
-  if (member instanceof GuildMember) {
-    userId = member.user.id;
-  } else {
-    userId = member;
-  }
+export async function removeMarriage(member: MemberResolvable) {
+  const userId = getUserId(member);
 
   const res = await prisma.marriage.findFirst({
     where: {

--- a/src/utils/functions/users/notifications.ts
+++ b/src/utils/functions/users/notifications.ts
@@ -1,11 +1,11 @@
 import { DMSettings, Preferences } from "@prisma/client";
-import { GuildMember } from "discord.js";
 import prisma from "../../../init/database";
 import redis from "../../../init/redis";
 import { InlineNotificationPayload, NotificationPayload } from "../../../types/Notification";
 import Constants from "../../Constants";
 import { dmQueue } from "../../queues/queues";
 import { createUser, userExists } from "../economy/utils";
+import { getUserId, MemberResolvable } from "../member";
 import ms = require("ms");
 
 declare function require(name: string): any;
@@ -22,36 +22,31 @@ const notificationsData: { [key: string]: NotificationData } =
 const preferencesData: { [key: string]: NotificationData } =
   require("../../../../data/notifications.json").preferences;
 
-export async function getDmSettings(member: GuildMember | string) {
-  let id: string;
-  if (member instanceof GuildMember) {
-    id = member.user.id;
-  } else {
-    id = member;
-  }
+export async function getDmSettings(member: MemberResolvable) {
+  const userId = getUserId(member);
 
-  if (await redis.exists(`${Constants.redis.cache.user.DM_SETTINGS}:${id}`)) {
+  if (await redis.exists(`${Constants.redis.cache.user.DM_SETTINGS}:${userId}`)) {
     return (await JSON.parse(
-      await redis.get(`${Constants.redis.cache.user.DM_SETTINGS}:${id}`),
+      await redis.get(`${Constants.redis.cache.user.DM_SETTINGS}:${userId}`),
     )) as DMSettings;
   }
 
   let query = await prisma.dMSettings.findUnique({
     where: {
-      userId: id,
+      userId,
     },
   });
 
   if (!query) {
     query = await prisma.dMSettings.create({
       data: {
-        userId: id,
+        userId,
       },
     });
   }
 
   await redis.set(
-    `${Constants.redis.cache.user.DM_SETTINGS}:${id}`,
+    `${Constants.redis.cache.user.DM_SETTINGS}:${userId}`,
     JSON.stringify(query),
     "EX",
     ms("12 hour") / 1000,
@@ -60,22 +55,17 @@ export async function getDmSettings(member: GuildMember | string) {
   return query;
 }
 
-export async function updateDmSettings(member: GuildMember | string, data: DMSettings) {
-  let id: string;
-  if (member instanceof GuildMember) {
-    id = member.user.id;
-  } else {
-    id = member;
-  }
+export async function updateDmSettings(member: MemberResolvable, data: DMSettings) {
+  const userId = getUserId(member);
 
   const query = await prisma.dMSettings.update({
     where: {
-      userId: id,
+      userId,
     },
     data,
   });
 
-  await redis.del(`${Constants.redis.cache.user.DM_SETTINGS}:${id}`);
+  await redis.del(`${Constants.redis.cache.user.DM_SETTINGS}:${userId}`);
 
   return query;
 }
@@ -88,17 +78,12 @@ export function getPreferencesData() {
   return preferencesData;
 }
 
-export async function getPreferences(member: GuildMember | string): Promise<Preferences> {
-  let id: string;
-  if (member instanceof GuildMember) {
-    id = member.user.id;
-  } else {
-    id = member;
-  }
+export async function getPreferences(member: MemberResolvable): Promise<Preferences> {
+  const userId = getUserId(member);
 
-  if (await redis.exists(`${Constants.redis.cache.user.PREFERENCES}:${id}`)) {
+  if (await redis.exists(`${Constants.redis.cache.user.PREFERENCES}:${userId}`)) {
     return JSON.parse(
-      await redis.get(`${Constants.redis.cache.user.PREFERENCES}:${id}`),
+      await redis.get(`${Constants.redis.cache.user.PREFERENCES}:${userId}`),
       // json cant parse bigints on its own so we have to do it manually
       (key, value) => {
         return key !== "userId" && typeof value === "string" && !isNaN(Number(value))
@@ -110,22 +95,22 @@ export async function getPreferences(member: GuildMember | string): Promise<Pref
 
   let query = await prisma.preferences.findUnique({
     where: {
-      userId: id,
+      userId: userId,
     },
   });
 
   if (!query) {
-    if (!(await userExists(id))) await createUser(id);
+    if (!(await userExists(userId))) await createUser(userId);
 
     query = await prisma.preferences.create({
       data: {
-        userId: id,
+        userId: userId,
       },
     });
   }
 
   await redis.set(
-    `${Constants.redis.cache.user.PREFERENCES}:${id}`,
+    `${Constants.redis.cache.user.PREFERENCES}:${userId}`,
     JSON.stringify(query, (key, value) => (typeof value === "bigint" ? Number(value) : value)),
     "EX",
     ms("12 hour") / 1000,
@@ -134,22 +119,17 @@ export async function getPreferences(member: GuildMember | string): Promise<Pref
   return query;
 }
 
-export async function updatePreferences(member: GuildMember | string, data: Preferences) {
-  let id: string;
-  if (member instanceof GuildMember) {
-    id = member.user.id;
-  } else {
-    id = member;
-  }
+export async function updatePreferences(member: MemberResolvable, data: Preferences) {
+  const userId = getUserId(member);
 
   const query = await prisma.preferences.update({
     where: {
-      userId: id,
+      userId,
     },
     data,
   });
 
-  await redis.del(`${Constants.redis.cache.user.PREFERENCES}:${id}`);
+  await redis.del(`${Constants.redis.cache.user.PREFERENCES}:${userId}`);
 
   return query;
 }
@@ -170,8 +150,8 @@ export async function addInlineNotification(...payload: InlineNotificationPayloa
 }
 
 // gets max of 8 and clears
-export async function getInlineNotifications(userId: string) {
-  const notifs = await redis.spop(`${Constants.redis.nypsi.INLINE_QUEUE}:${userId}`, 8);
+export async function getInlineNotifications(member: MemberResolvable) {
+  const notifs = await redis.spop(`${Constants.redis.nypsi.INLINE_QUEUE}:${getUserId(member)}`, 8);
 
   return notifs.map((i) => JSON.parse(i) as InlineNotificationPayload);
 }

--- a/src/utils/functions/users/tag.ts
+++ b/src/utils/functions/users/tag.ts
@@ -1,26 +1,21 @@
-import { GuildMember } from "discord.js";
 import prisma from "../../../init/database";
 import redis from "../../../init/redis";
 import Constants from "../../Constants";
+import { getUserId, MemberResolvable } from "../member";
 
-export async function updateLastKnownUsername(member: GuildMember | string, tag: string) {
-  let id: string;
-  if (member instanceof GuildMember) {
-    id = member.user.id;
-  } else {
-    id = member;
-  }
+export async function updateLastKnownUsername(member: MemberResolvable, tag: string) {
+  const userId = getUserId(member);
 
   await prisma.user.update({
     where: {
-      id: id,
+      id: userId,
     },
     data: {
       lastKnownUsername: tag,
     },
   });
 
-  await redis.set(`${Constants.redis.cache.user.username}:${id}`, tag, "EX", 7200);
+  await redis.set(`${Constants.redis.cache.user.username}:${userId}`, tag, "EX", 7200);
 }
 
 export async function getLastKnownUsername(id: string) {

--- a/src/utils/functions/users/tags.ts
+++ b/src/utils/functions/users/tags.ts
@@ -3,8 +3,11 @@ import redis from "../../../init/redis";
 import Constants from "../../Constants";
 import { logger } from "../../logger";
 import { getTagsData } from "../economy/utils";
+import { getUserId, MemberResolvable } from "../member";
 
-export async function getTags(userId: string) {
+export async function getTags(member: MemberResolvable) {
+  const userId = getUserId(member);
+
   const cache = await redis.get(`${Constants.redis.cache.user.tags}:${userId}`);
 
   if (cache) {
@@ -30,7 +33,9 @@ export async function getTags(userId: string) {
   return query;
 }
 
-export async function removeTag(userId: string, tagId: string) {
+export async function removeTag(member: MemberResolvable, tagId: string) {
+  const userId = getUserId(member);
+
   await redis.del(`${Constants.redis.cache.user.tags}:${userId}`);
 
   await prisma.tags.delete({
@@ -45,7 +50,9 @@ export async function removeTag(userId: string, tagId: string) {
   return getTags(userId);
 }
 
-export async function addTag(userId: string, tagId: string) {
+export async function addTag(member: MemberResolvable, tagId: string) {
+  const userId = getUserId(member);
+
   const tags = getTagsData();
 
   if (!tags[tagId]) {
@@ -68,7 +75,9 @@ export async function addTag(userId: string, tagId: string) {
   return getTags(userId);
 }
 
-export async function setActiveTag(userId: string, tagId: string) {
+export async function setActiveTag(member: MemberResolvable, tagId: string) {
+  const userId = getUserId(member);
+
   await redis.del(`${Constants.redis.cache.user.tags}:${userId}`);
 
   await prisma.tags.updateMany({
@@ -94,8 +103,8 @@ export async function setActiveTag(userId: string, tagId: string) {
   return getTags(userId);
 }
 
-export async function getActiveTag(userId: string) {
-  const tags = await getTags(userId);
+export async function getActiveTag(member: MemberResolvable) {
+  const tags = await getTags(member);
 
   return tags.find((i) => i.selected);
 }

--- a/src/utils/functions/users/views.ts
+++ b/src/utils/functions/users/views.ts
@@ -3,10 +3,13 @@ import prisma from "../../../init/database";
 import redis from "../../../init/redis";
 import Constants from "../../Constants";
 import { logger } from "../../logger";
+import { getUserId, MemberResolvable } from "../member";
 import ms = require("ms");
 import dayjs = require("dayjs");
 
-export async function getViews(userId: string, limit?: Date) {
+export async function getViews(member: MemberResolvable, limit?: Date) {
+  const userId = getUserId(member);
+
   const cache = await redis.get(`${Constants.redis.cache.user.views}:${userId}`);
 
   if (cache)
@@ -38,7 +41,10 @@ export async function getViews(userId: string, limit?: Date) {
   return query;
 }
 
-export async function addView(userId: string, viewerId: string, source: string) {
+export async function addView(member: MemberResolvable, viewer: MemberResolvable, source: string) {
+  const userId = getUserId(member);
+  const viewerId = getUserId(viewer);
+
   if (userId === viewerId) return;
   const views = await getViews(userId, dayjs().subtract(5, "minute").toDate());
 

--- a/src/utils/functions/users/wordle.ts
+++ b/src/utils/functions/users/wordle.ts
@@ -1,18 +1,19 @@
 import prisma from "../../../init/database";
 import { addProgress } from "../economy/achievements";
 import { addTaskProgress } from "../economy/tasks";
+import { getUserId, MemberResolvable } from "../member";
 
 export async function addWordleGame(
-  userId: string,
+  member: MemberResolvable,
   win: boolean,
   guesses: string[],
   ms: number,
   word: string,
 ) {
   if (win) {
-    addProgress(userId, "wordle", 1);
-    addTaskProgress(userId, "wordles_daily");
-    addTaskProgress(userId, "wordles_weekly");
+    addProgress(member, "wordle", 1);
+    addTaskProgress(member, "wordles_daily");
+    addTaskProgress(member, "wordles_weekly");
   }
 
   const id = await prisma.wordleGame.create({
@@ -21,7 +22,7 @@ export async function addWordleGame(
       won: win,
       word,
       guesses,
-      userId,
+      userId: getUserId(member),
     },
     select: {
       id: true,

--- a/src/utils/handlers/commandhandler.ts
+++ b/src/utils/handlers/commandhandler.ts
@@ -1036,7 +1036,7 @@ export async function runCommand(
       logger.info(`news shown to ${message.author.username}`);
     }
 
-    const notifs = await getInlineNotifications(message.author.id);
+    const notifs = await getInlineNotifications(message.member);
 
     if (notifs.length > 0) embeds.push(...notifs.map((i) => i.embed));
 
@@ -1114,7 +1114,7 @@ export async function runCommand(
   ]);
 
   setProgress(
-    message.author.id,
+    message.member,
     "discordian",
     parseInt(await redis.hget(Constants.redis.nypsi.TOP_COMMANDS_USER, message.author.id)) || 0,
   );


### PR DESCRIPTION
the functions were very inconsistent with some only allowing userId, some GuildMember, etc. now they almost all take MemberResolvable, which can be GuildMember | APIInteractionGuildMember | User | string. the ones that i didnt change either cant be changed (ex needs GuildMember to get username/avatar), or they were specific to one call or something so there was no real need to change them. i also went through all the commands files and tried to standardize those (use message.member when possible, use message.author.id for id if needed)

if youre confused at why getUserId is done in the way that it is, for some reason sometimes (at least in x) making a User object doesnt get recognized as a user in instanceof, so it tries to do user.user.id instead and errors and blows up

i hope you appreciate my hours of changing tiny little things!!