### PR TITLE
fix: try/catch for incorrect MemberResolvable/undefined

### DIFF
--- a/src/utils/functions/member.ts
+++ b/src/utils/functions/member.ts
@@ -236,9 +236,10 @@ export function getUserId(user: MemberResolvable): string {
     if (typeof user === "string") return user;
     if (typeof (user as any).id === "string") return (user as any).id;
     return (user as APIInteractionGuildMember).user.id;
-  } catch {
+  } catch (err) {
     if (user) {
       logger.error("failed to fetch user id", { user });
+      console.error(err);
     }
     return undefined;
   }

--- a/src/utils/functions/member.ts
+++ b/src/utils/functions/member.ts
@@ -232,7 +232,14 @@ export async function getRole(guild: Guild, roleName: string): Promise<Role> {
 export type MemberResolvable = GuildMember | APIInteractionGuildMember | User | string;
 
 export function getUserId(user: MemberResolvable): string {
-  if (typeof user === "string") return user;
-  if (typeof (user as any).id === "string") return (user as any).id;
-  return (user as APIInteractionGuildMember).user.id;
+  try {
+    if (typeof user === "string") return user;
+    if (typeof (user as any).id === "string") return (user as any).id;
+    return (user as APIInteractionGuildMember).user.id;
+  } catch {
+    if (user) {
+      logger.error("failed to fetch user id", { user });
+    }
+    return undefined;
+  }
 }


### PR DESCRIPTION
fixes an issue when undefined is passed in after no one completes a lootdrop and errors

i dont think this fixes some lootdrops not responding, but i cant replicate it. i did multiple loot drops on my bot and didnt get a single error one