### PR TITLE
fix: dont delete counters on first fail

### DIFF
--- a/src/commands/counter.ts
+++ b/src/commands/counter.ts
@@ -6,6 +6,7 @@ import {
   InteractionReplyOptions,
   Message,
   PermissionFlagsBits,
+  VoiceChannel,
 } from "discord.js";
 import { Command, NypsiCommandInteraction, NypsiMessage } from "../models/Command";
 import { CustomEmbed, ErrorEmbed } from "../models/EmbedBuilders.js";
@@ -200,19 +201,29 @@ async function run(
         embeds: [new ErrorEmbed("failed to create counter")],
       });
 
-    return send({ embeds: [new CustomEmbed(message.member, "✅ successfully created counter.")] });
+    return send({ embeds: [new CustomEmbed(message.member, "✅ successfully created counter")] });
   } else if (args[0].toLowerCase() === "delete") {
-    const channel = message.options.getChannel("channel");
+    const channel = message.options.getChannel("channel") as VoiceChannel;
 
     const res = await deleteGuildCounter(channel.id);
 
     if (!res)
       return send({ embeds: [new ErrorEmbed("that channel does not have a counter tied to it")] });
+
+    let deleted = false;
+
+    try {
+      await channel.delete("counter removed");
+      deleted = true;
+    } catch {
+      //silent fail
+    }
+
     return send({
       embeds: [
         new CustomEmbed(
           message.member,
-          "✅ counter removed, you will have to manually delete the channel",
+          `✅ counter removed${deleted ? "" : ", you will have to manually delete the channel"}`,
         ),
       ],
     });

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -250,6 +250,7 @@ export default {
       TRADE_FULFILLING: "nypsi:trade:fulfilling",
       MARKET_DM: "nypsi:market:dm",
       DOCS_CONTENT: "nypsi:docs",
+      COUNTER_ERROR: "nypsi:counter:error",
     },
   },
   ANNOUNCEMENTS_CHANNEL_ID: "747057465245564939",


### PR DESCRIPTION
counters will now be deleted from db only after failing 50 times (8.33 hours)

also, made it so when the channel is created it starts with the most up to date name instead of "creating..." to not mess up rate limit

also also, made it automatically delete the channel when removing a counter