### PR TITLE
store guild members in db

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,7 @@ model User {
   FlagGame                 FlagGame[]
   Event                    Event[]
   EventContribution        EventContribution[]
+  guilds                   GuildMember[]
 }
 
 model ProfileView {
@@ -614,6 +615,17 @@ model Guild {
   ModerationEvidence  ModerationEvidence[]
   GuildEvidenceCredit GuildEvidenceCredit[]
   ChatFilter          ChatFilter[]
+  members             GuildMember[]
+}
+
+model GuildMember {
+  guildId String
+  userId  String
+
+  user  User? @relation(fields: [userId], references: [id])
+  guild Guild @relation(fields: [guildId], references: [id])
+
+  @@id([guildId, userId])
 }
 
 model ChatFilter {
@@ -847,7 +859,7 @@ enum EconomyGuildRole {
 }
 
 model EconomyGuildMember {
-  userId    String   @unique
+  userId    String           @unique
   guildName String
   joinedAt  DateTime
   role      EconomyGuildRole @default(member)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -619,6 +619,8 @@ model Guild {
 }
 
 model GuildMember {
+  createdAt DateTime @default(now())
+
   guildId String
   userId  String
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -852,12 +852,12 @@ model EconomyGuildMember {
   joinedAt  DateTime
   role      EconomyGuildRole @default(member)
 
-  contributedMoney          BigInt   @default(0)
-  contributedXp             Int      @default(0)
-  contributedMoneyThisLevel BigInt   @default(0)
-  contributedXpThisLevel    Int      @default(0)
-  contributedMoneyToday     BigInt   @default(0)
-  contributedXpToday        Int      @default(0)
+  contributedMoney          BigInt @default(0)
+  contributedXp             Int    @default(0)
+  contributedMoneyThisLevel BigInt @default(0)
+  contributedXpThisLevel    Int    @default(0)
+  contributedMoneyToday     BigInt @default(0)
+  contributedXpToday        Int    @default(0)
 
   economy Economy      @relation(fields: [userId], references: [userId], onDelete: Cascade)
   guild   EconomyGuild @relation(fields: [guildName], references: [guildName], onDelete: Cascade)

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -158,6 +158,8 @@ export default {
         EVIDENCE_MAX: "cache:guilds:evidence:max",
         AUTOMUTE_VL: "cache:guild:automute",
         CHATFILTER: "cache:guild:chatfilter",
+        MEMBERS: "cache:guild:members",
+        MEMBERS_LAST_FETCHED: "cache:guild:members:last_fetched",
       },
       chatReaction: {
         EXISTS: "cache:chatreaction:exists",

--- a/src/utils/functions/guilds/members.ts
+++ b/src/utils/functions/guilds/members.ts
@@ -1,0 +1,85 @@
+import { Guild } from "discord.js";
+import prisma from "../../../init/database";
+import redis from "../../../init/redis";
+import Constants from "../../Constants";
+import { Mutex } from "../mutex";
+import ms = require("ms");
+
+async function getDatabaseMembers(guildId: string) {
+  const cache = await redis.get(`${Constants.redis.cache.guild.MEMBERS}:${guildId}`);
+
+  if (cache) {
+    return JSON.parse(cache) as string[];
+  }
+
+  const members = await prisma.guildMember
+    .findMany({ where: { guildId }, select: { userId: true } })
+    .then((members) => members.map(({ userId }) => userId));
+
+  await redis.set(
+    `${Constants.redis.cache.guild.MEMBERS}:${guildId}`,
+    JSON.stringify(members),
+    "EX",
+    ms("30 minute") / 1000,
+  );
+}
+
+async function checkMembers(guildId: string, discordMembers: string[]) {
+  const databaseMembers = await getDatabaseMembers(guildId);
+
+  const dbSet = new Set(databaseMembers);
+  const discordSet = new Set(discordMembers);
+
+  const missing = [...new Set(discordMembers.filter((x) => !dbSet.has(x)))];
+  const extra = [...new Set(databaseMembers.filter((x) => !discordSet.has(x)))];
+
+  if (missing.length > 0) {
+    await prisma.guildMember.createMany({
+      data: missing.map((userId) => ({ guildId, userId })),
+    });
+    redis.del(`${Constants.redis.cache.guild.MEMBERS}:${guildId}`);
+  }
+
+  if (extra.length > 0) {
+    await prisma.guildMember.deleteMany({ where: { guildId, userId: { in: extra } } });
+    redis.del(`${Constants.redis.cache.guild.MEMBERS}:${guildId}`);
+  }
+}
+
+const mutex = new Mutex();
+
+export async function getAllMembers(guild: Guild) {
+  await mutex.acquire(`member_fetch_${guild.id}`);
+  try {
+    const lastFetched = await redis
+      .get(`${Constants.redis.cache.guild.MEMBERS_LAST_FETCHED}:${guild.id}`)
+      .then((v) => (v ? parseInt(v) : 0));
+
+    if (lastFetched > Date.now() - ms("10 minute")) {
+      return getDatabaseMembers(guild.id);
+    }
+
+    let discordMembers: string[];
+
+    if (guild.memberCount === guild.members.cache.size) {
+      discordMembers = guild.members.cache.map((member) => member.id);
+    } else {
+      discordMembers = await guild.members
+        .fetch()
+        .then((members) => members.map((member) => member.id));
+    }
+
+    await redis.set(
+      `${Constants.redis.cache.guild.MEMBERS_LAST_FETCHED}:${guild.id}`,
+      Date.now(),
+      "EX",
+      ms("10 minute") / 1000,
+    );
+
+    checkMembers(guild.id, discordMembers);
+
+    return discordMembers;
+  } finally {
+    mutex.release(`member_fetch_${guild.id}`);
+  }
+}


### PR DESCRIPTION
discord is introducing harsher rate limits on fetching all members for a guild, one request per 30 seconds per guild

still pretty lenient, but this is needed to stop hitting that rate limit.

the main issue being leaderboards, EVERY guild leaderboard command does a full guild member fetch. that's insane, and not needed!

my initial thought was to use caching, but there was several problems with that initial approach:
1. i thought it said 30 minutes not 30 seconds
2. caused a memory leak

so now gonna use the database to store this shite, should be alright!

# todo list
- [x] database table
- [ ] functions
- [ ] replace all usages of `members.fetch()`